### PR TITLE
feat: Hono RPC の基盤セットアップ

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
     ]
   },
   "dependencies": {
+    "@hono/zod-validator": "0.7.6",
     "@tailwindcss/postcss": "4.2.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
+    "hono": "4.12.1",
     "lucide-react": "0.575.0",
     "next": "16.1.6",
     "postcss": "8.5.6",
@@ -30,7 +32,8 @@
     "react-dom": "19.2.4",
     "tailwind-merge": "3.5.0",
     "tailwindcss": "4.2.0",
-    "tw-animate-css": "1.4.0"
+    "tw-animate-css": "1.4.0",
+    "zod": "4.3.6"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@hono/zod-validator':
+        specifier: 0.7.6
+        version: 0.7.6(hono@4.12.1)(zod@4.3.6)
       '@tailwindcss/postcss':
         specifier: 4.2.0
         version: 4.2.0
@@ -17,6 +20,9 @@ importers:
       clsx:
         specifier: 2.1.1
         version: 2.1.1
+      hono:
+        specifier: 4.12.1
+        version: 4.12.1
       lucide-react:
         specifier: 0.575.0
         version: 0.575.0(react@19.2.4)
@@ -41,6 +47,9 @@ importers:
       tw-animate-css:
         specifier: 1.4.0
         version: 1.4.0
+      zod:
+        specifier: 4.3.6
+        version: 4.3.6
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.4
@@ -386,6 +395,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@hono/zod-validator@0.7.6':
+    resolution: {integrity: sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw==}
+    peerDependencies:
+      hono: '>=3.9.0'
+      zod: ^3.25.0 || ^4.0.0
 
   '@img/colour@1.0.0':
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
@@ -1279,6 +1294,10 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hono@4.12.1:
+    resolution: {integrity: sha512-hi9afu8g0lfJVLolxElAZGANCTTl6bewIdsRNhaywfP9K8BPf++F2z6OLrYGIinUwpRKzbZHMhPwvc0ZEpAwGw==}
+    engines: {node: '>=16.9.0'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -1931,6 +1950,9 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
 snapshots:
 
   '@adobe/css-tools@4.4.4': {}
@@ -2158,6 +2180,11 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.3':
     optional: true
+
+  '@hono/zod-validator@0.7.6(hono@4.12.1)(zod@4.3.6)':
+    dependencies:
+      hono: 4.12.1
+      zod: 4.3.6
 
   '@img/colour@1.0.0':
     optional: true
@@ -2970,6 +2997,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hono@4.12.1: {}
+
   html-escaper@2.0.2: {}
 
   image-size@2.0.2: {}
@@ -3563,3 +3592,5 @@ snapshots:
       is-wsl: 3.1.1
 
   yallist@3.1.1: {}
+
+  zod@4.3.6: {}

--- a/src/app/api/[[...route]]/route.ts
+++ b/src/app/api/[[...route]]/route.ts
@@ -1,0 +1,8 @@
+import { handle } from "hono/vercel";
+import app from "@/server";
+
+export const GET = handle(app);
+export const POST = handle(app);
+export const PUT = handle(app);
+export const DELETE = handle(app);
+export const PATCH = handle(app);

--- a/src/lib/rpc.ts
+++ b/src/lib/rpc.ts
@@ -1,0 +1,4 @@
+import { hc } from "hono/client";
+import type { AppType } from "@/server";
+
+export const client = hc<AppType>("/");

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,0 +1,9 @@
+import { Hono } from "hono";
+import { healthRoute } from "./routes/health";
+
+const app = new Hono().basePath("/api");
+
+const routes = app.route("/health", healthRoute);
+
+export type AppType = typeof routes;
+export default app;

--- a/src/server/routes/health.ts
+++ b/src/server/routes/health.ts
@@ -1,0 +1,7 @@
+import { Hono } from "hono";
+
+const app = new Hono().get("/", (c) => {
+  return c.json({ status: "ok", timestamp: Date.now() });
+});
+
+export { app as healthRoute };


### PR DESCRIPTION
## Summary
- Hono を Next.js App Router の Route Handler にマウントし、型安全な API 通信基盤を構築
- `hc` クライアントによる RPC 型推論の仕組みを導入（`AppType` エクスポート）
- 動作確認用のヘルスチェック API (`GET /api/health`) を追加

## 新規ファイル
| ファイル | 役割 |
|---|---|
| `src/server/index.ts` | メイン Hono アプリ定義・ルート集約・AppType エクスポート |
| `src/server/routes/health.ts` | ヘルスチェック API |
| `src/app/api/[[...route]]/route.ts` | Next.js Route Handler（Hono マウント） |
| `src/lib/rpc.ts` | hc クライアントインスタンス |

## 追加パッケージ
- `hono` 4.12.1
- `zod` 4.3.6
- `@hono/zod-validator` 0.7.6

## Test plan
- [x] `pnpm exec tsc --noEmit` — 型チェックエラーなし
- [x] `pnpm lint` — Biome lint 警告なし
- [x] `curl http://localhost:3000/api/health` — `{"status":"ok","timestamp":...}` 正常応答

🤖 Generated with [Claude Code](https://claude.com/claude-code)