### PR TITLE
ci: GitHub Actions CI ワークフローを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+
+  type-check:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm type-check
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: npx playwright install chromium --with-deps
+      - run: pnpm vitest run

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "biome check .",
     "lint:fix": "biome check --fix .",
     "format": "biome format --write .",
+    "type-check": "tsc --noEmit",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "test": "vitest"


### PR DESCRIPTION
## Summary
- PR作成/更新時に lint・type-check・test を並列実行する GitHub Actions CI を追加
- `package.json` に `type-check` スクリプト (`tsc --noEmit`) を追加
- `.github/workflows/ci.yml` で Lint / Type Check / Test の3並列ジョブを定義

## Test plan
- [ ] PR上で GitHub Actions の3ジョブ (Lint, Type Check, Test) が並列実行されることを確認
- [ ] 各ジョブが成功で完了することを確認
- [ ] CI実行後、Settings > Branches でブランチ保護ルールを設定する

🤖 Generated with [Claude Code](https://claude.com/claude-code)