### PR TITLE
feat: アイコンライブラリを Phosphor Icons に移行

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -473,6 +473,7 @@ pending ──→ accepted
 - **カード**: 情報を詰め込まず、呼吸のある構成。タイトルに `font-serif font-light tracking-wide`
 - **モーション**: 0.2〜0.4秒 ease-out、hover scale は 1.02 以下。派手なアニメーションは非推奨
 - **フォーム**: Label + Input を `flex flex-col gap-2` で縦並び。合成フォームは `rounded-sm border bg-card p-8` + `gap-6`
+- **アイコン**: Phosphor Icons（`@phosphor-icons/react`）を使用。ウェイトは `light` を基本とし、アクティブ状態や強調には `regular` を使用する。アイコンは最小限に留め、「アイコンがなくても伝わる」ことを優先する。サイズは `size-4`〜`size-5`（16〜20px）、色は `text-muted-foreground` を基本とする
 
 ### 6.2 アーキテクチャ・実装規約
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@hono/zod-validator": "0.7.6",
+    "@phosphor-icons/react": "2.1.10",
     "@tailwindcss/postcss": "4.2.0",
     "better-auth": "1.4.19",
     "better-sqlite3": "12.6.2",
@@ -36,7 +37,6 @@
     "clsx": "2.1.1",
     "drizzle-orm": "0.45.1",
     "hono": "4.12.1",
-    "lucide-react": "0.575.0",
     "next": "16.1.6",
     "postcss": "8.5.6",
     "radix-ui": "1.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@hono/zod-validator':
         specifier: 0.7.6
         version: 0.7.6(hono@4.12.1)(zod@4.3.6)
+      '@phosphor-icons/react':
+        specifier: 2.1.10
+        version: 2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tailwindcss/postcss':
         specifier: 4.2.0
         version: 4.2.0
@@ -32,9 +35,6 @@ importers:
       hono:
         specifier: 4.12.1
         version: 4.12.1
-      lucide-react:
-        specifier: 0.575.0
-        version: 0.575.0(react@19.2.4)
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -987,6 +987,13 @@ packages:
   '@noble/hashes@2.0.1':
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
     engines: {node: '>= 20.19.0'}
+
+  '@phosphor-icons/react@2.1.10':
+    resolution: {integrity: sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>= 16.8'
+      react-dom: '>= 16.8'
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -2811,11 +2818,6 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-react@0.575.0:
-    resolution: {integrity: sha512-VuXgKZrk0uiDlWjGGXmKV6MSk9Yy4l10qgVvzGn2AWBx1Ylt0iBexKOAoA6I7JO3m+M9oeovJd3yYENfkUbOeg==}
-    peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -4006,6 +4008,11 @@ snapshots:
   '@noble/ciphers@2.1.1': {}
 
   '@noble/hashes@2.0.1': {}
+
+  '@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -5731,10 +5738,6 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
-
-  lucide-react@0.575.0(react@19.2.4):
-    dependencies:
-      react: 19.2.4
 
   lz-string@1.5.0: {}
 

--- a/src/app/_components/app-header.tsx
+++ b/src/app/_components/app-header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowLeft, Menu } from "lucide-react";
+import { ArrowLeft, List } from "@phosphor-icons/react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useHeaderConfig } from "@/app/_components/header-config";
@@ -25,7 +25,7 @@ export function AppHeader() {
               aria-label="戻る"
               className="text-muted-foreground transition-transform duration-200 hover:-translate-x-0.5"
             >
-              <ArrowLeft className="size-5" />
+              <ArrowLeft weight="light" className="size-5" />
             </Button>
           )}
         </div>
@@ -46,7 +46,7 @@ export function AppHeader() {
             aria-label="メニュー"
             className="text-muted-foreground"
           >
-            <Menu className="size-5" />
+            <List weight="light" className="size-5" />
           </Button>
         </div>
       </div>

--- a/src/app/_components/navigation-sheet.tsx
+++ b/src/app/_components/navigation-sheet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Home, LogOut, Plus } from "lucide-react";
+import { House, Plus, SignOut } from "@phosphor-icons/react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import {
@@ -12,7 +12,7 @@ import {
 import { authClient } from "@/lib/auth-client";
 
 const navItems = [
-  { href: "/dashboard", label: "ホーム", icon: Home },
+  { href: "/dashboard", label: "ホーム", icon: House },
   { href: "/events/new", label: "イベントを作成", icon: Plus },
   // { href: "/settings", label: "設定", icon: Settings },
 ] as const;
@@ -54,7 +54,7 @@ export function NavigationSheet({ open, onOpenChange }: NavigationSheetProps) {
                     : "text-muted-foreground hover:bg-accent/30 hover:text-foreground"
                 }`}
               >
-                <Icon className="size-4" />
+                <Icon weight="light" className="size-4" />
                 {label}
               </Link>
             );
@@ -67,7 +67,7 @@ export function NavigationSheet({ open, onOpenChange }: NavigationSheetProps) {
             onClick={handleSignOut}
             className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-sm text-muted-foreground transition-colors duration-200 hover:bg-accent/30 hover:text-foreground"
           >
-            <LogOut className="size-4" />
+            <SignOut weight="light" className="size-4" />
             ログアウト
           </button>
         </div>

--- a/src/app/_components/navigation-sheet.tsx
+++ b/src/app/_components/navigation-sheet.tsx
@@ -61,7 +61,7 @@ export function NavigationSheet({ open, onOpenChange }: NavigationSheetProps) {
           })}
         </nav>
 
-        <div className="mt-auto border-t pt-4">
+        <div className="mt-auto border-t py-4">
           <button
             type="button"
             onClick={handleSignOut}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { XIcon } from "lucide-react";
+import { X } from "@phosphor-icons/react";
 import { Dialog as SheetPrimitive } from "radix-ui";
 import type * as React from "react";
 
@@ -76,7 +76,7 @@ function SheetContent({
         {children}
         {showCloseButton && (
           <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
-            <XIcon className="size-4" />
+            <X weight="light" className="size-4" />
             <span className="sr-only">Close</span>
           </SheetPrimitive.Close>
         )}


### PR DESCRIPTION
## Summary

- `lucide-react` から `@phosphor-icons/react` に移行し、全アイコンに `weight="light"` を適用
- 対象ファイル: `sheet.tsx`, `app-header.tsx`, `navigation-sheet.tsx` の 3 ファイル / 6 アイコン
- `docs/requirements.md` セクション 6.1 にアイコンの方針を追記

## Test plan

- [x] `pnpm type-check` — エラーなし
- [x] `pnpm lint` — 警告なし
- [x] `pnpm build` — ビルド成功
- [x] `pnpm storybook` で `app-header` / `navigation-sheet` のストーリーを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)