### PR TITLE
fix(vercel): invoke pnpm build so serwist generates sw.js

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,3 @@
 {
-  "buildCommand": "next build"
+  "buildCommand": "pnpm build"
 }


### PR DESCRIPTION
## Summary
- `vercel.json` の `buildCommand` を `next build` から `pnpm build` に変更
- これにより `package.json` の `"build": "next build && serwist build"` が Vercel 上でも実行されるようになり、`public/sw.js` が生成されてデプロイに含まれる

## 背景
本番（https://lull-nu.vercel.app）のコンソールで以下のエラーが発生していた：

```
Uncaught (in promise) TypeError: Failed to register a ServiceWorker for scope ('https://lull-nu.vercel.app/') with script ('https://lull-nu.vercel.app/sw.js'): A bad HTTP response code (404) was received when fetching the script.
```

Vercel のビルドログを確認したところ、`next build` は実行されていたが `serwist build` の出力（`The service worker file was written to public/sw.js`）が一切なかった。原因は `vercel.json` で `buildCommand` が `next build` に上書きされており、`package.json` の build script が呼ばれていなかったこと。Turbopack 対応のため `serwist build` CLI を使う構成を維持するため、`buildCommand` を `pnpm build` に変える最小修正で対応。

## Test plan
- [ ] Vercel の Preview デプロイが成功する
- [ ] Preview 環境のビルドログに `The service worker file was written to public/sw.js` が出力される
- [ ] Preview 環境で `/sw.js` が 200 で取得できる
- [ ] ブラウザのコンソールに ServiceWorker 登録失敗のエラーが出ない

🤖 Generated with [Claude Code](https://claude.com/claude-code)