### PR TITLE
feat(auth): use Google OAuth emulator in Vercel PR previews

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,5 +7,8 @@ BETTER_AUTH_SECRET=
 BETTER_AUTH_URL=http://localhost:3000
 
 # Google OAuth
+# local / production: 本物の値を入れる
+# Vercel preview: emulate 用ダミー値（client=emulate-client / secret=emulate-secret）を preview scope に設定し、
+# あわせて NEXT_PUBLIC_VERCEL_ENV=preview を preview scope に入れると @emulators/google が有効化される
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,28 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {
-  turbopack: {},
+const isPreview = process.env.VERCEL_ENV === "preview";
+const stubPath = "./src/lib/emulate-stub.ts";
+
+const baseConfig: NextConfig = {
+  turbopack: {
+    resolveAlias: isPreview
+      ? {}
+      : {
+          "@emulators/adapter-next": stubPath,
+          "@emulators/google": stubPath,
+        },
+  },
+  ...(isPreview
+    ? {}
+    : {
+        outputFileTracingExcludes: {
+          "**/*": ["node_modules/@emulators/**"],
+        },
+      }),
 };
 
-export default nextConfig;
+export default async function config(): Promise<NextConfig> {
+  if (!isPreview) return baseConfig;
+  const { withEmulate } = await import("@emulators/adapter-next");
+  return withEmulate(baseConfig);
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,10 @@
 import type { NextConfig } from "next";
 
-const isPreview = process.env.VERCEL_ENV === "preview";
+// preview 判定は `src/lib/env.ts` と同じ式を直接書く。
+// env.ts を import すると定数伝播に頼る形になり、Turbopack の
+// resolveAlias 切替や dead-branch DCE が効かなくなる恐れがあるため、
+// ここは literal 参照のまま維持する。
+const isPreview = process.env.NEXT_PUBLIC_VERCEL_ENV === "preview";
 const stubPath = "./src/lib/emulate-stub.ts";
 
 const baseConfig: NextConfig = {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     ]
   },
   "dependencies": {
+    "@emulators/adapter-next": "0.4.1",
+    "@emulators/google": "0.4.1",
     "@hono/zod-validator": "0.7.6",
     "@libsql/client": "0.17.2",
     "@phosphor-icons/react": "2.1.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@emulators/adapter-next':
+        specifier: 0.4.1
+        version: 0.4.1
+      '@emulators/google':
+        specifier: 0.4.1
+        version: 0.4.1
       '@hono/zod-validator':
         specifier: 0.7.6
         version: 0.7.6(hono@4.12.12)(zod@4.3.6)
@@ -370,6 +376,15 @@ packages:
 
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
+
+  '@emulators/adapter-next@0.4.1':
+    resolution: {integrity: sha512-Lfv8lYM7N1otOdDNsHU0NHM5Ch3yjt3Pw90GoOHXnwJFpORxLCQyb0J5nVByqyh9+XFhw5g5IWsnGAhr0lU07w==}
+
+  '@emulators/core@0.4.1':
+    resolution: {integrity: sha512-LtF0JlwNusmlY2tesBcMcwWGr1xxXdhzqhd+Il2ajuykmCaOzO3t0x4PexVCeWeZc4MafB6IpCqBHtSuHdj9Sg==}
+
+  '@emulators/google@0.4.1':
+    resolution: {integrity: sha512-9aaOCbPqexQ9ScKkD8+OR/MQWh8YC+FENT/20EFQBoO4VRA2eA2BvnbJgM2F5JRGjb6Xbw/BvJ0R6PU1N3FQLQ==}
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
@@ -3286,6 +3301,9 @@ packages:
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
 
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
 
@@ -4593,6 +4611,21 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@emulators/adapter-next@0.4.1':
+    dependencies:
+      '@emulators/core': 0.4.1
+
+  '@emulators/core@0.4.1':
+    dependencies:
+      hono: 4.12.12
+      jose: 6.2.2
+
+  '@emulators/google@0.4.1':
+    dependencies:
+      '@emulators/core': 0.4.1
+      hono: 4.12.12
+      jose: 6.1.3
 
   '@esbuild-kit/core-utils@3.3.2':
     dependencies:
@@ -7166,6 +7199,8 @@ snapshots:
   jiti@2.6.1: {}
 
   jose@6.1.3: {}
+
+  jose@6.2.2: {}
 
   js-base64@3.7.8: {}
 

--- a/src/app/_components/join-event-form.tsx
+++ b/src/app/_components/join-event-form.tsx
@@ -43,11 +43,18 @@ export function JoinEventForm({
   };
 
   const handleJoinWithGoogle = () => {
-    // OAuth 前に表示名を sessionStorage に保存
     setSavedDisplayName(displayName);
+    const target = `/join/${token}`;
+    if (process.env.NEXT_PUBLIC_VERCEL_ENV === "preview") {
+      authClient.signIn.oauth2({
+        providerId: "google",
+        callbackURL: target,
+      });
+      return;
+    }
     authClient.signIn.social({
       provider: "google",
-      callbackURL: `/join/${token}`,
+      callbackURL: target,
     });
   };
 

--- a/src/app/_components/sign-in-button.tsx
+++ b/src/app/_components/sign-in-button.tsx
@@ -9,9 +9,17 @@ type SignInButtonProps = {
 
 export function SignInButton({ callbackURL }: SignInButtonProps) {
   const handleSignIn = () => {
+    const target = callbackURL ?? "/dashboard";
+    if (process.env.NEXT_PUBLIC_VERCEL_ENV === "preview") {
+      authClient.signIn.oauth2({
+        providerId: "google",
+        callbackURL: target,
+      });
+      return;
+    }
     authClient.signIn.social({
       provider: "google",
-      callbackURL: callbackURL ?? "/dashboard",
+      callbackURL: target,
     });
   };
 

--- a/src/app/emulate/[...path]/route.ts
+++ b/src/app/emulate/[...path]/route.ts
@@ -1,0 +1,97 @@
+import type { NextRequest } from "next/server";
+
+type RouteContext = { params: Promise<{ path: string[] }> };
+type MethodHandler = (req: NextRequest, ctx: RouteContext) => Promise<Response>;
+type EmulateHandlers = {
+  GET: MethodHandler;
+  POST: MethodHandler;
+  PUT: MethodHandler;
+  PATCH: MethodHandler;
+  DELETE: MethodHandler;
+};
+
+const NOT_FOUND: MethodHandler = async () =>
+  new Response(null, { status: 404 });
+const NOT_FOUND_HANDLERS: EmulateHandlers = {
+  GET: NOT_FOUND,
+  POST: NOT_FOUND,
+  PUT: NOT_FOUND,
+  PATCH: NOT_FOUND,
+  DELETE: NOT_FOUND,
+};
+
+const handlersPromise: Promise<EmulateHandlers> =
+  process.env.NEXT_PUBLIC_VERCEL_ENV === "preview"
+    ? (async () => {
+        const [{ createEmulateHandler }, googleModule] = await Promise.all([
+          import("@emulators/adapter-next"),
+          import("@emulators/google"),
+        ]);
+
+        const branchUrl = process.env.VERCEL_BRANCH_URL
+          ? `https://${process.env.VERCEL_BRANCH_URL}`
+          : undefined;
+        const deploymentUrl = process.env.VERCEL_URL
+          ? `https://${process.env.VERCEL_URL}`
+          : undefined;
+
+        const redirectUris = Array.from(
+          new Set(
+            [
+              "http://localhost:3000/api/auth/oauth2/callback/google",
+              branchUrl && `${branchUrl}/api/auth/oauth2/callback/google`,
+              deploymentUrl &&
+                `${deploymentUrl}/api/auth/oauth2/callback/google`,
+            ].filter((v): v is string => Boolean(v)),
+          ),
+        );
+
+        return createEmulateHandler({
+          services: {
+            google: {
+              emulator: googleModule,
+              seed: {
+                oauth_clients: [
+                  {
+                    client_id: process.env.GOOGLE_CLIENT_ID ?? "emulate-client",
+                    client_secret:
+                      process.env.GOOGLE_CLIENT_SECRET ?? "emulate-secret",
+                    name: "Lull Preview",
+                    redirect_uris: redirectUris,
+                  },
+                ],
+                users: [
+                  {
+                    email: "preview-tester@example.com",
+                    name: "Preview Tester",
+                    given_name: "Preview",
+                    family_name: "Tester",
+                    email_verified: true,
+                  },
+                ],
+              },
+            },
+          },
+        }) as EmulateHandlers;
+      })()
+    : Promise.resolve(NOT_FOUND_HANDLERS);
+
+async function dispatch(
+  method: keyof EmulateHandlers,
+  req: NextRequest,
+  ctx: RouteContext,
+) {
+  const handlers = await handlersPromise;
+  return handlers[method](req, ctx);
+}
+
+export const GET = (req: NextRequest, ctx: RouteContext) =>
+  dispatch("GET", req, ctx);
+export const POST = (req: NextRequest, ctx: RouteContext) =>
+  dispatch("POST", req, ctx);
+export const PUT = (req: NextRequest, ctx: RouteContext) =>
+  dispatch("PUT", req, ctx);
+export const PATCH = (req: NextRequest, ctx: RouteContext) =>
+  dispatch("PATCH", req, ctx);
+export const DELETE = (req: NextRequest, ctx: RouteContext) =>
+  dispatch("DELETE", req, ctx);

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -1,7 +1,12 @@
 import { genericOAuthClient } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
 
+const baseURL =
+  typeof window !== "undefined"
+    ? window.location.origin
+    : (process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000");
+
 export const authClient = createAuthClient({
-  baseURL: process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000",
+  baseURL,
   plugins: [genericOAuthClient()],
 });

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -1,5 +1,7 @@
+import { genericOAuthClient } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
 
 export const authClient = createAuthClient({
   baseURL: process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000",
+  plugins: [genericOAuthClient()],
 });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,7 +1,24 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { genericOAuth } from "better-auth/plugins";
 import { db } from "@/db";
 import * as schema from "@/db/schema";
+
+const isPreview = process.env.VERCEL_ENV === "preview";
+
+const withHttps = (host: string | undefined) =>
+  host ? `https://${host}` : undefined;
+
+const previewBranchUrl = withHttps(process.env.VERCEL_BRANCH_URL);
+const previewDeploymentUrl = withHttps(process.env.VERCEL_URL);
+const previewBaseUrl =
+  previewBranchUrl ?? previewDeploymentUrl ?? "http://localhost:3000";
+const previewTrustedOrigins = [previewBranchUrl, previewDeploymentUrl].filter(
+  (v): v is string => Boolean(v),
+);
+
+const googleClientId = process.env.GOOGLE_CLIENT_ID as string;
+const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET as string;
 
 export const auth = betterAuth({
   database: drizzleAdapter(db, {
@@ -9,12 +26,40 @@ export const auth = betterAuth({
     schema,
     usePlural: true,
   }),
-  socialProviders: {
-    google: {
-      clientId: process.env.GOOGLE_CLIENT_ID as string,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
-    },
-  },
+  ...(isPreview
+    ? {
+        baseURL: previewBaseUrl,
+        trustedOrigins: previewTrustedOrigins,
+        plugins: [
+          genericOAuth({
+            config: [
+              {
+                providerId: "google",
+                clientId: googleClientId,
+                clientSecret: googleClientSecret,
+                discoveryUrl: `${previewBaseUrl}/emulate/google/.well-known/openid-configuration`,
+                scopes: ["openid", "email", "profile"],
+                pkce: true,
+                mapProfileToUser: (profile) => ({
+                  id: profile.sub,
+                  email: profile.email,
+                  name: profile.name,
+                  image: profile.picture,
+                  emailVerified: profile.email_verified ?? true,
+                }),
+              },
+            ],
+          }),
+        ],
+      }
+    : {
+        socialProviders: {
+          google: {
+            clientId: googleClientId,
+            clientSecret: googleClientSecret,
+          },
+        },
+      }),
   session: {
     expiresIn: 60 * 60 * 24 * 7,
     updateAge: 60 * 60 * 24,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,8 +3,7 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { genericOAuth } from "better-auth/plugins";
 import { db } from "@/db";
 import * as schema from "@/db/schema";
-
-const isPreview = process.env.VERCEL_ENV === "preview";
+import { isPreview } from "@/lib/env";
 
 const withHttps = (host: string | undefined) =>
   host ? `https://${host}` : undefined;

--- a/src/lib/emulate-stub.ts
+++ b/src/lib/emulate-stub.ts
@@ -1,0 +1,3 @@
+throw new Error(
+  "@emulators/* は preview ビルドでのみ利用できます (stub loaded)",
+);

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,12 @@
+// Vercel preview 判定はこのモジュール経由に統一する。
+// `NEXT_PUBLIC_VERCEL_ENV` を見ている理由:
+// - client 側でも使う必要があるため `NEXT_PUBLIC_*` 必須
+// - `src/app/emulate/[...path]/route.ts` の dynamic import と
+//   `next.config.ts` の `turbopack.resolveAlias` は、build 時 literal inline
+//   による DCE / alias 切替に依存している。これらの箇所では本モジュールを
+//   経由せず、直接 `process.env.NEXT_PUBLIC_VERCEL_ENV === "preview"` を
+//   書くこと。定数伝播に頼ると DCE が効かず production bundle に
+//   `@emulators/*` 実体が残るリスクがある。
+// - Vercel preview scope では `NEXT_PUBLIC_VERCEL_ENV=preview` を手動設定する
+//   （`VERCEL_ENV` は自動で入るが、client bundle には露出しないため採用しない）
+export const isPreview = process.env.NEXT_PUBLIC_VERCEL_ENV === "preview";


### PR DESCRIPTION
## Summary

- Vercel PR preview で `vercel-labs/emulate` の Google emulator を使ってサインインを通せるようにし、本物の Google OAuth credential をチームに配らずに済むようにする
- production は従来どおり `socialProviders.google`。preview 時のみ Better Auth を `genericOAuth` に切り替え、`/emulate/google` にマウントした emulator の discovery を指す
- `turbopack.resolveAlias` + stub 差し替えで production build から `@emulators/*` を完全除外（nft.json / runtime chunks どちらからも emulator 実体ゼロ）

## 実装メモ

**preview 判定は `NEXT_PUBLIC_VERCEL_ENV` 一本**
- `process.env.VERCEL_ENV` は Next.js / Turbopack で build 時 literal 置換されないため、サーバ側の dead branch でも dynamic import が残ってしまう
- `NEXT_PUBLIC_*` は build 時 inline されるので、これで統一することで IIFE 三項式の dead branch ごと DCE できる
- あわせて Vercel preview scope に `NEXT_PUBLIC_VERCEL_ENV=preview` を設定済み（production / development には入れない）

**genericOAuth の callback path は `socialProviders` と別**
- `/api/auth/sign-in/oauth2` と `/api/auth/oauth2/callback/:providerId` を使う
- emulate 側 `oauth_clients.redirect_uris` もそれに合わせてある
- クライアントも `sign-in-button.tsx` / `join-event-form.tsx` で preview 時のみ `authClient.signIn.oauth2({ providerId: "google" })` を呼ぶように分岐

**production への影響**
- `@emulators/*` 実体は production bundle に含まれない（alias で stub 1 行に差し替え）
- `/emulate/[...path]` ルート自体は production にも存在するが、`NEXT_PUBLIC_VERCEL_ENV !== "preview"` で即 404 を返す薄い壁
- `better-auth/client/plugins` の `genericOAuthClient` は client bundle に top-level で含まれる（数 KB）
- production の既存の sign-in フロー (`signIn.social`) は不変

## Vercel preview で追加で踏んだ問題と対処

ローカル preview mode では動いたが、Vercel の実 preview で 3 段階はまったので記録。

**1. `auth-client.ts` の baseURL が production URL を指して CORS 403**
- `NEXT_PUBLIC_APP_URL` が Vercel preview scope で production URL にセットされており、preview ドメインから production の `/api/auth/*` を叩いていた
- ブラウザでは `window.location.origin` を使うように修正（`bf3e3f2`）

**2. Better Auth の `trustedOrigins` チェックで 403**
- サーバ側が `BETTER_AUTH_URL`（= production URL）を baseURL として扱い、preview branch URL からのリクエストを信頼しない origin として弾いていた
- preview では `VERCEL_BRANCH_URL` を `baseURL` に明示し、`trustedOrigins` に branch URL / deployment URL の両方を入れる（`666c6d8`）
- emulate route の `redirect_uris` も同様に両 URL を含めるよう修正

**3. Deployment Protection で `INVALID_OAUTH_CONFIGURATION` 400**
- preview に Vercel Deployment Protection がかかっており、Better Auth のサーバー側 self-fetch（discovery / token / userinfo endpoint）がすべて 401 HTML を受け取っていた
- ブラウザは Vercel SSO cookie を持っているので直接開けば JSON が見えるが、同一デプロイ内のサーバー → 自身 への fetch には cookie が乗らない
- 対処: この preview の Deployment Protection を Off に（emulator の目的と相反するため）

## Test plan

- [x] `pnpm type-check`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] preview dev server で `/emulate/google/.well-known/openid-configuration` が 200 で返り、discovery の endpoint 群が `http://localhost:3000/emulate/google/...` にプレフィクスされていることを確認
- [x] 非 preview 起動では上記 discovery が 404 を返すことを確認（ガード動作）
- [x] `pnpm build` 後、`.next/server/app/emulate/[...path]/route.js.nft.json` から emulator 参照が 0、.js ランタイム chunks にも `@emulators/` 実体が残っていないことを確認
- [x] `git grep -n socialProviders src/lib/auth.ts` で production パスが残存
- [x] `sign-in-button.tsx` / `join-event-form.tsx` の両方に preview 分岐と production パス (`signIn.social`) が残存
- [x] **手動・デプロイ後**: PR preview デプロイで sign-in ボタン押下 → emulate の user picker → `preview-tester@example.com` 選択 → セッションが張られてアプリトップに戻る
- [x] **手動・デプロイ後**: devtools で sign-in のネットワークリクエストが `/api/auth/sign-in/oauth2` に飛んでいることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)