### PR TITLE
fix(qr-scanner): カメラ権限をボタン押下のジェスチャー直下で要求

### DIFF
--- a/src/app/_components/check-in-view.tsx
+++ b/src/app/_components/check-in-view.tsx
@@ -82,6 +82,7 @@ export function CheckInView({
   const [listOpen, setListOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [searching, setSearching] = useState(false);
+  const [isRequestingCamera, setIsRequestingCamera] = useState(false);
 
   const handleScan = useCallback(
     async (decodedText: string) => {
@@ -238,6 +239,8 @@ export function CheckInView({
   };
 
   const startScanning = async () => {
+    // 権限ダイアログ表示中の連打で getUserMedia が多重実行されるのを防ぐ
+    if (isRequestingCamera) return;
     // PWA / iOS Safari で権限ダイアログを確実に出すため、
     // ユーザー操作のコールスタックから直接 getUserMedia を呼ぶ
     if (
@@ -250,6 +253,7 @@ export function CheckInView({
       });
       return;
     }
+    setIsRequestingCamera(true);
     try {
       const stream = await navigator.mediaDevices.getUserMedia({
         video: { facingMode: "environment" },
@@ -273,6 +277,8 @@ export function CheckInView({
             : "カメラの起動に失敗しました",
       });
       return;
+    } finally {
+      setIsRequestingCamera(false);
     }
     setScanKey((k) => k + 1);
     setViewState({ mode: "scanning" });
@@ -347,9 +353,14 @@ export function CheckInView({
 
       {/* QR スキャンボタン（上部に常設） */}
       {viewState.mode !== "scanning" ? (
-        <Button onClick={startScanning} size="lg" className="w-full gap-2">
+        <Button
+          onClick={startScanning}
+          size="lg"
+          className="w-full gap-2"
+          disabled={isRequestingCamera}
+        >
           <QrCode className="size-5" />
-          QR スキャン
+          {isRequestingCamera ? "カメラを起動中..." : "QR スキャン"}
         </Button>
       ) : (
         <div className="space-y-4">

--- a/src/app/_components/check-in-view.tsx
+++ b/src/app/_components/check-in-view.tsx
@@ -237,7 +237,43 @@ export function CheckInView({
     }
   };
 
-  const startScanning = () => {
+  const startScanning = async () => {
+    // PWA / iOS Safari で権限ダイアログを確実に出すため、
+    // ユーザー操作のコールスタックから直接 getUserMedia を呼ぶ
+    if (
+      typeof navigator === "undefined" ||
+      !navigator.mediaDevices?.getUserMedia
+    ) {
+      setViewState({
+        mode: "error",
+        message: "お使いのブラウザはカメラ機能に対応していません",
+      });
+      return;
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: "environment" },
+        audio: false,
+      });
+      // html5-qrcode 側で再度 getUserMedia が呼ばれるので、ここでは停止
+      for (const track of stream.getTracks()) {
+        track.stop();
+      }
+    } catch (err: unknown) {
+      const isDenied =
+        err instanceof DOMException &&
+        (err.name === "NotAllowedError" ||
+          err.name === "PermissionDeniedError");
+      setViewState({
+        mode: "error",
+        message: isDenied
+          ? "カメラへのアクセスが許可されていません。ブラウザまたは端末の設定からカメラを許可してください。"
+          : err instanceof Error
+            ? err.message
+            : "カメラの起動に失敗しました",
+      });
+      return;
+    }
     setScanKey((k) => k + 1);
     setViewState({ mode: "scanning" });
   };

--- a/src/app/_components/qr-scanner.tsx
+++ b/src/app/_components/qr-scanner.tsx
@@ -8,55 +8,10 @@ type QrScannerProps = {
   onScan: (decodedText: string) => void;
 };
 
-type ScannerStatus =
-  | "requesting"
-  | "starting"
-  | "scanning"
-  | "denied"
-  | "error";
-
-/** カメラ権限状態を取得（未対応ブラウザでは null） */
-async function queryCameraPermission(): Promise<PermissionState | null> {
-  if (typeof navigator === "undefined" || !navigator.permissions?.query) {
-    return null;
-  }
-  try {
-    const result = await navigator.permissions.query({
-      name: "camera" as PermissionName,
-    });
-    return result.state;
-  } catch {
-    return null;
-  }
-}
-
-/** getUserMedia を明示的に呼び出して権限を取得する（PWA / iOS Safari 対策） */
-async function requestCameraPermission(): Promise<void> {
-  if (
-    typeof navigator === "undefined" ||
-    !navigator.mediaDevices?.getUserMedia
-  ) {
-    throw new Error("お使いのブラウザはカメラ機能に対応していません");
-  }
-  const stream = await navigator.mediaDevices.getUserMedia({
-    video: { facingMode: "environment" },
-    audio: false,
-  });
-  // Html5Qrcode が内部で getUserMedia を呼ぶため、取得済み stream はここで停止
-  for (const track of stream.getTracks()) {
-    track.stop();
-  }
-}
-
-function isPermissionDeniedError(err: unknown): boolean {
-  return (
-    err instanceof DOMException &&
-    (err.name === "NotAllowedError" || err.name === "PermissionDeniedError")
-  );
-}
+type ScannerStatus = "starting" | "scanning" | "error";
 
 export function QrScanner({ onScan }: QrScannerProps) {
-  const [status, setStatus] = useState<ScannerStatus>("requesting");
+  const [status, setStatus] = useState<ScannerStatus>("starting");
   const [errorMessage, setErrorMessage] = useState<string>("");
   const [attempt, setAttempt] = useState(0);
   const onScanRef = useRef(onScan);
@@ -72,89 +27,48 @@ export function QrScanner({ onScan }: QrScannerProps) {
   // biome-ignore lint/correctness/useExhaustiveDependencies: attempt は再試行時に effect を強制再実行するためのトリガー
   useEffect(() => {
     let cancelled = false;
-    let html5QrCode: Html5Qrcode | null = null;
-    let startPromise: Promise<unknown> = Promise.resolve();
+    const html5QrCode = new Html5Qrcode(elementId, {
+      formatsToSupport: [Html5QrcodeSupportedFormats.QR_CODE],
+      verbose: false,
+    });
 
-    const run = async () => {
-      // 1. 権限状態を事前確認。denied の場合はダイアログを出さずに即エラー表示
-      const permission = await queryCameraPermission();
-      if (cancelled) return;
-      if (permission === "denied") {
-        setStatus("denied");
-        return;
-      }
-
-      // 2. 明示的に getUserMedia を呼んで権限ダイアログを発火させる。
-      //    PWA / iOS Safari では html5-qrcode の内部呼び出しだけだと
-      //    プロンプトが表示されないケースがあるため、ここで必ず叩く
-      try {
-        await requestCameraPermission();
-      } catch (err: unknown) {
-        if (cancelled) return;
-        if (isPermissionDeniedError(err)) {
-          setStatus("denied");
-        } else {
-          setStatus("error");
-          setErrorMessage(
-            err instanceof Error ? err.message : "カメラの起動に失敗しました",
-          );
+    const startPromise = html5QrCode
+      .start(
+        { facingMode: "environment" },
+        { fps: 10, qrbox: { width: 250, height: 250 } },
+        (decodedText) => {
+          html5QrCode.pause(false);
+          handleScan(decodedText);
+        },
+        () => {},
+      )
+      .then(() => {
+        if (cancelled) {
+          return html5QrCode
+            .stop()
+            .then(() => html5QrCode.clear())
+            .catch(() => {});
         }
-        return;
-      }
-      if (cancelled) return;
-
-      // 3. スキャナー起動
-      setStatus("starting");
-      html5QrCode = new Html5Qrcode(elementId, {
-        formatsToSupport: [Html5QrcodeSupportedFormats.QR_CODE],
-        verbose: false,
+        setStatus("scanning");
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setStatus("error");
+        setErrorMessage(
+          err instanceof Error ? err.message : "カメラの起動に失敗しました",
+        );
       });
-
-      startPromise = html5QrCode
-        .start(
-          { facingMode: "environment" },
-          { fps: 10, qrbox: { width: 250, height: 250 } },
-          (decodedText) => {
-            html5QrCode?.pause(false);
-            handleScan(decodedText);
-          },
-          () => {},
-        )
-        .then(() => {
-          if (cancelled) {
-            return html5QrCode
-              ?.stop()
-              .then(() => html5QrCode?.clear())
-              .catch(() => {});
-          }
-          setStatus("scanning");
-        })
-        .catch((err: unknown) => {
-          if (cancelled) return;
-          if (isPermissionDeniedError(err)) {
-            setStatus("denied");
-          } else {
-            setStatus("error");
-            setErrorMessage(
-              err instanceof Error ? err.message : "カメラの起動に失敗しました",
-            );
-          }
-        });
-    };
-
-    run();
 
     return () => {
       cancelled = true;
       // start() 完了を待ってから停止する（play() interrupted 回避）
       startPromise.then(() => {
-        if (!html5QrCode) return;
         const state = html5QrCode.getState();
         // 2 = SCANNING, 3 = PAUSED
         if (state === 2 || state === 3) {
           html5QrCode
             .stop()
-            .then(() => html5QrCode?.clear())
+            .then(() => html5QrCode.clear())
             .catch(() => {});
         } else {
           try {
@@ -169,31 +83,14 @@ export function QrScanner({ onScan }: QrScannerProps) {
 
   const retry = () => {
     setErrorMessage("");
-    setStatus("requesting");
+    setStatus("starting");
     setAttempt((n) => n + 1);
   };
 
   return (
     <div className="flex flex-col items-center gap-4">
-      {status === "requesting" && (
-        <p className="text-muted-foreground text-sm">
-          カメラへのアクセスを許可してください...
-        </p>
-      )}
       {status === "starting" && (
         <p className="text-muted-foreground text-sm">カメラを起動中...</p>
-      )}
-      {status === "denied" && (
-        <div className="flex flex-col items-center gap-3">
-          <p className="text-destructive text-sm text-center">
-            カメラへのアクセスが許可されていません。
-            <br />
-            ブラウザまたは端末の設定からカメラを許可した上で、再試行してください。
-          </p>
-          <Button variant="outline" size="sm" onClick={retry}>
-            再試行
-          </Button>
-        </div>
       )}
       {status === "error" && (
         <div className="flex flex-col items-center gap-3">

--- a/src/app/_components/qr-scanner.tsx
+++ b/src/app/_components/qr-scanner.tsx
@@ -16,7 +16,8 @@ export function QrScanner({ onScan }: QrScannerProps) {
   const [attempt, setAttempt] = useState(0);
   const onScanRef = useRef(onScan);
   const reactId = useId();
-  const elementId = `qr-scanner-${reactId.replace(/:/g, "")}`;
+  // attempt を id に含めることで、再試行時に effect の依存が変わり再実行される
+  const elementId = `qr-scanner-${reactId.replace(/:/g, "")}-${attempt}`;
 
   onScanRef.current = onScan;
 
@@ -24,7 +25,6 @@ export function QrScanner({ onScan }: QrScannerProps) {
     onScanRef.current(decodedText);
   }, []);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: attempt は再試行時に effect を強制再実行するためのトリガー
   useEffect(() => {
     let cancelled = false;
     const html5QrCode = new Html5Qrcode(elementId, {
@@ -43,12 +43,7 @@ export function QrScanner({ onScan }: QrScannerProps) {
         () => {},
       )
       .then(() => {
-        if (cancelled) {
-          return html5QrCode
-            .stop()
-            .then(() => html5QrCode.clear())
-            .catch(() => {});
-        }
+        if (cancelled) return;
         setStatus("scanning");
       })
       .catch((err: unknown) => {
@@ -79,7 +74,7 @@ export function QrScanner({ onScan }: QrScannerProps) {
         }
       });
     };
-  }, [elementId, handleScan, attempt]);
+  }, [elementId, handleScan]);
 
   const retry = () => {
     setErrorMessage("");


### PR DESCRIPTION
## Summary

- `QrScanner` の `useEffect` 内で `getUserMedia` を呼んでいたため、PWA / iOS Safari ではユーザージェスチャー直下とみなされず権限ダイアログが出ないケースがあった
- 「QR スキャン」ボタンの `onClick`（`startScanning`）から同期的に `getUserMedia` を呼び、許可が取れてから初めて `QrScanner` をマウントする流れに変更
- `QrScanner` 側の事前権限取得ロジック（`queryCameraPermission` / `requestCameraPermission` / `denied` ステータス）は親側に責務が移ったため削除し、Html5Qrcode の起動に専念するシンプルな構造に

## なぜこの変更が必要か

#41 でも PWA のカメラ権限問題に対応していたが、`useEffect` 経由の呼び出しではブラウザによってユーザージェスチャー由来と認識されず、権限ダイアログが表示されないことがある。ボタンの `onClick` ハンドラ内から直接 `await navigator.mediaDevices.getUserMedia()` を呼ぶことで、クリックイベント直下のコールスタックからプロンプトが発火するようになる。

## Test plan

- [ ] PWA としてインストールした状態で「QR スキャン」ボタン押下 → 権限ダイアログが表示される
- [ ] 権限許可後、QR スキャナーが正常に起動する
- [ ] 権限拒否時にエラーメッセージが表示される
- [ ] 再度「QR スキャン」ボタンを押すとリトライできる
- [ ] デスクトップブラウザでも従来どおり動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)