### PR TITLE
feat(guest): ゲスト招待画面を「招待状 → 当日のパス」として再設計

### DIFF
--- a/src/app/_components/invitation-response-form.tsx
+++ b/src/app/_components/invitation-response-form.tsx
@@ -86,7 +86,7 @@ export function InvitationResponseForm({
         if (result.fieldErrors) setFieldErrors(result.fieldErrors);
       } else {
         setSuccess(true);
-        if (isUpdate) setIsOpen(false);
+        setIsOpen(false);
       }
     });
   };

--- a/src/app/_components/invitation-response-form.tsx
+++ b/src/app/_components/invitation-response-form.tsx
@@ -7,10 +7,6 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import type { InvitationStatus } from "@/db/schema";
 
-// ============================================================
-// 型定義
-// ============================================================
-
 type InvitationResponseFormProps = {
   token: string;
   invitation: {
@@ -20,10 +16,6 @@ type InvitationResponseFormProps = {
     companions: { id: string; name: string }[];
   };
 };
-
-// ============================================================
-// InvitationResponseForm
-// ============================================================
 
 type CompanionEntry = { key: string; name: string };
 
@@ -55,6 +47,7 @@ export function InvitationResponseForm({
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [isPending, startTransition] = useTransition();
   const [success, setSuccess] = useState(false);
+  const [isOpen, setIsOpen] = useState(!isUpdate);
 
   const handleAddCompanion = () => {
     if (companions.length >= 4) return;
@@ -93,135 +86,200 @@ export function InvitationResponseForm({
         if (result.fieldErrors) setFieldErrors(result.fieldErrors);
       } else {
         setSuccess(true);
+        if (isUpdate) setIsOpen(false);
       }
     });
   };
 
+  if (!isOpen) {
+    return (
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-2">
+          <p className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+            RSVP
+          </p>
+          <h2 className="font-serif text-2xl leading-tight">
+            回答は送信済みです
+          </h2>
+          {success && (
+            <p className="mt-3 font-serif text-sm text-accent-foreground animate-in fade-in slide-in-from-top-1 duration-500 motion-reduce:animate-none">
+              回答を受け取りました
+            </p>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            setSuccess(false);
+            setIsOpen(true);
+          }}
+          className="self-start rounded-sm px-1 py-1 text-sm underline underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        >
+          回答を変更する
+        </button>
+      </div>
+    );
+  }
+
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-      <h2 className="text-lg font-light tracking-wide">
-        {isUpdate ? "回答を変更" : "出欠を回答"}
-      </h2>
-
-      {error && (
-        <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-          {error}
-        </div>
-      )}
-
-      {success && (
-        <div className="rounded-md bg-green-50 p-3 text-sm text-green-700 dark:bg-green-950 dark:text-green-300">
-          回答を送信しました
-        </div>
-      )}
-
-      {/* ゲスト名 */}
+    <form onSubmit={handleSubmit} className="flex flex-col gap-8">
       <div className="flex flex-col gap-2">
-        <Label htmlFor="guestName">お名前</Label>
-        <Input
-          id="guestName"
-          type="text"
-          value={guestName}
-          onChange={(e) => setGuestName(e.target.value)}
-          required
-          maxLength={100}
-          placeholder="お名前を入力"
-        />
-        {fieldErrors.guestName && (
-          <p className="text-sm text-destructive">{fieldErrors.guestName}</p>
+        <p className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+          RSVP
+        </p>
+        <h2 className="font-serif text-2xl leading-tight">
+          {isUpdate ? "回答を変更する" : "出欠をお聞かせください"}
+        </h2>
+        {success && (
+          <p className="mt-3 font-serif text-sm text-accent-foreground animate-in fade-in slide-in-from-top-1 duration-500 motion-reduce:animate-none">
+            回答を受け取りました
+          </p>
+        )}
+        {error && (
+          <p className="mt-3 border-t border-destructive/30 pt-3 text-sm text-destructive">
+            {error}
+          </p>
         )}
       </div>
 
-      {/* メールアドレス */}
-      <div className="flex flex-col gap-2">
-        <Label htmlFor="guestEmail">メールアドレス</Label>
-        <Input
-          id="guestEmail"
-          type="email"
-          value={guestEmail}
-          onChange={(e) => setGuestEmail(e.target.value)}
-          required
-          placeholder="メールアドレスを入力"
-        />
-        {fieldErrors.guestEmail && (
-          <p className="text-sm text-destructive">{fieldErrors.guestEmail}</p>
-        )}
-      </div>
-
-      {/* 出欠選択 */}
-      <div className="flex flex-col gap-2">
-        <Label>出欠</Label>
-        <div className="flex gap-4">
-          <label className="flex items-center gap-2">
-            <input
-              type="radio"
-              name="attendance"
-              value="accepted"
-              checked={attendance === "accepted"}
-              onChange={() => setAttendance("accepted")}
-              className="accent-primary"
-            />
-            <span>出席</span>
-          </label>
-          <label className="flex items-center gap-2">
-            <input
-              type="radio"
-              name="attendance"
-              value="declined"
-              checked={attendance === "declined"}
-              onChange={() => setAttendance("declined")}
-              className="accent-primary"
-            />
-            <span>辞退</span>
-          </label>
+      <fieldset
+        disabled={isPending}
+        className="flex flex-col gap-8 disabled:opacity-70"
+      >
+        {/* ゲスト名 */}
+        <div className="flex flex-col gap-2">
+          <Label
+            htmlFor="guestName"
+            className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground"
+          >
+            お名前
+          </Label>
+          <Input
+            id="guestName"
+            type="text"
+            value={guestName}
+            onChange={(e) => setGuestName(e.target.value)}
+            required
+            maxLength={100}
+            placeholder="お名前を入力"
+          />
+          {fieldErrors.guestName && (
+            <p className="text-xs text-destructive">{fieldErrors.guestName}</p>
+          )}
         </div>
-      </div>
 
-      {/* 同伴者 */}
-      {attendance === "accepted" && (
+        {/* メールアドレス */}
+        <div className="flex flex-col gap-2">
+          <Label
+            htmlFor="guestEmail"
+            className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground"
+          >
+            メールアドレス
+          </Label>
+          <Input
+            id="guestEmail"
+            type="email"
+            value={guestEmail}
+            onChange={(e) => setGuestEmail(e.target.value)}
+            required
+            placeholder="name@example.com"
+          />
+          {fieldErrors.guestEmail && (
+            <p className="text-xs text-destructive">{fieldErrors.guestEmail}</p>
+          )}
+        </div>
+
+        {/* 出欠選択 */}
         <div className="flex flex-col gap-3">
-          <Label>同伴者（最大4名）</Label>
-          {companions.map((companion, index) => (
-            <div key={companion.key} className="flex items-center gap-2">
-              <Input
-                type="text"
-                value={companion.name}
-                onChange={(e) =>
-                  handleCompanionChange(companion.key, e.target.value)
-                }
-                maxLength={100}
-                placeholder={`同伴者${index + 1}のお名前`}
+          <p className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+            出欠
+          </p>
+          <div className="grid grid-cols-1 gap-3">
+            <label className="block cursor-pointer rounded-sm border border-border/50 p-5 text-left transition-colors has-[input:checked]:border-foreground has-[input:checked]:bg-foreground/[0.03] focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-background">
+              <input
+                type="radio"
+                name="attendance"
+                value="accepted"
+                checked={attendance === "accepted"}
+                onChange={() => setAttendance("accepted")}
+                className="sr-only"
               />
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => handleRemoveCompanion(companion.key)}
-              >
-                削除
-              </Button>
-            </div>
-          ))}
-          {companions.length < 4 && (
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={handleAddCompanion}
-              className="self-start"
-            >
-              同伴者を追加
-            </Button>
-          )}
-          {fieldErrors.companions && (
-            <p className="text-sm text-destructive">{fieldErrors.companions}</p>
-          )}
+              <p className="font-serif text-lg">出席します</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                ご来場をお待ちしています
+              </p>
+            </label>
+            <label className="block cursor-pointer rounded-sm border border-border/50 p-5 text-left transition-colors has-[input:checked]:border-foreground has-[input:checked]:bg-foreground/[0.03] focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-background">
+              <input
+                type="radio"
+                name="attendance"
+                value="declined"
+                checked={attendance === "declined"}
+                onChange={() => setAttendance("declined")}
+                className="sr-only"
+              />
+              <p className="font-serif text-lg">辞退します</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                また次の機会にお会いできますように
+              </p>
+            </label>
+          </div>
         </div>
-      )}
 
-      {/* 送信ボタン */}
-      <Button type="submit" disabled={isPending} className="self-start">
-        {isPending ? "送信中..." : isUpdate ? "回答を変更" : "回答を送信"}
+        {/* 同伴者 */}
+        {attendance === "accepted" && (
+          <div className="flex flex-col gap-3 border-t border-border/50 pt-6">
+            <p className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+              同伴者（最大 4 名）
+            </p>
+            {companions.map((companion, index) => (
+              <div key={companion.key} className="flex items-center gap-2">
+                <Input
+                  type="text"
+                  value={companion.name}
+                  onChange={(e) =>
+                    handleCompanionChange(companion.key, e.target.value)
+                  }
+                  maxLength={100}
+                  placeholder={`同伴者 ${index + 1} のお名前`}
+                />
+                <button
+                  type="button"
+                  onClick={() => handleRemoveCompanion(companion.key)}
+                  className="shrink-0 rounded-sm px-2 py-1 text-xs text-muted-foreground underline underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                >
+                  削除
+                </button>
+              </div>
+            ))}
+            {companions.length < 4 && (
+              <button
+                type="button"
+                onClick={handleAddCompanion}
+                className="self-start rounded-sm px-1 py-1 text-sm underline underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              >
+                同伴者を追加
+              </button>
+            )}
+            {fieldErrors.companions && (
+              <p className="text-xs text-destructive">
+                {fieldErrors.companions}
+              </p>
+            )}
+          </div>
+        )}
+      </fieldset>
+
+      <Button
+        type="submit"
+        disabled={isPending}
+        className="h-12 w-full bg-foreground text-background tracking-[0.15em] hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-70"
+      >
+        {isPending
+          ? "送信中..."
+          : isUpdate
+            ? "回答を変更する"
+            : "回答を送信する"}
       </Button>
     </form>
   );

--- a/src/app/_components/qr-code.tsx
+++ b/src/app/_components/qr-code.tsx
@@ -3,12 +3,24 @@
 import QRCode from "qrcode";
 import { useEffect, useState } from "react";
 
-export function QrCode({ path }: { path: string }) {
+type QrCodeProps = {
+  path: string;
+  eventName?: string;
+  eventDatetime?: string;
+  caption?: string;
+};
+
+export function QrCode({
+  path,
+  eventName,
+  eventDatetime,
+  caption,
+}: QrCodeProps) {
   const [dataUrl, setDataUrl] = useState<string | null>(null);
 
   useEffect(() => {
     const url = `${window.location.origin}${path}`;
-    QRCode.toDataURL(url, { width: 200, margin: 2 })
+    QRCode.toDataURL(url, { width: 240, margin: 2 })
       .then(setDataUrl)
       .catch((error) => {
         console.error("Failed to generate QR code:", error);
@@ -16,15 +28,36 @@ export function QrCode({ path }: { path: string }) {
       });
   }, [path]);
 
-  if (!dataUrl) return null;
-
   return (
-    <div className="flex flex-col items-center gap-2">
-      {/* biome-ignore lint/performance/noImgElement: data URL のため next/image 不要 */}
-      <img src={dataUrl} alt="QR コード" width={200} height={200} />
-      <p className="text-sm text-muted-foreground">
-        受付でこの QR コードを提示してください
+    <div className="flex flex-col items-center gap-5 rounded-sm border border-border/50 bg-background px-6 py-8">
+      <p className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+        Admission Pass
       </p>
+      {dataUrl ? (
+        // biome-ignore lint/performance/noImgElement: data URL のため next/image 不要
+        <img
+          src={dataUrl}
+          alt={`${eventName ?? "イベント"} のチェックイン用 QR コード`}
+          width={240}
+          height={240}
+          className="size-60"
+        />
+      ) : (
+        <div className="size-60 animate-pulse rounded-sm bg-muted/40" />
+      )}
+      {(eventName || eventDatetime) && (
+        <div className="flex flex-col items-center gap-1">
+          {eventName && (
+            <p className="font-serif text-base leading-tight">{eventName}</p>
+          )}
+          {eventDatetime && (
+            <p className="text-xs tabular-nums text-muted-foreground">
+              {eventDatetime}
+            </p>
+          )}
+        </div>
+      )}
+      {caption && <p className="text-xs text-muted-foreground">{caption}</p>}
     </div>
   );
 }

--- a/src/app/i/[token]/page.tsx
+++ b/src/app/i/[token]/page.tsx
@@ -1,4 +1,9 @@
-import { CheckCircle, Circle } from "@phosphor-icons/react/dist/ssr";
+import {
+  CheckCircle,
+  Circle,
+  User,
+  UsersThree,
+} from "@phosphor-icons/react/dist/ssr";
 import { InvitationResponseForm } from "@/app/_components/invitation-response-form";
 import { QrCode } from "@/app/_components/qr-code";
 import type { EventStatus } from "@/db/schema";
@@ -6,19 +11,42 @@ import { formatDatetime, formatTime } from "@/lib/format";
 import { getInvitationByToken } from "@/lib/queries/invitations";
 
 // ============================================================
-// ローカルコンポーネント
+// Shell
 // ============================================================
 
-function ErrorView({ message }: { message: string }) {
+function GuestShell({ children }: { children: React.ReactNode }) {
   return (
-    <div className="mx-auto max-w-2xl px-6 py-12">
-      <div className="flex flex-col items-center gap-4 py-16 text-center">
-        <h1 className="text-2xl font-light tracking-wide">招待リンクエラー</h1>
-        <p className="text-muted-foreground">{message}</p>
+    <div className="min-h-dvh bg-background">
+      <div className="mx-auto flex max-w-md flex-col gap-10 px-6 pt-[max(2.5rem,env(safe-area-inset-top))] pb-[max(2.5rem,env(safe-area-inset-bottom))]">
+        {children}
       </div>
     </div>
   );
 }
+
+// ============================================================
+// Error
+// ============================================================
+
+function ErrorView({ title, message }: { title: string; message: string }) {
+  return (
+    <GuestShell>
+      <div className="mt-16 flex flex-col items-center gap-4 text-center animate-in fade-in slide-in-from-bottom-1 duration-700 motion-reduce:animate-none">
+        <p className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+          Lull
+        </p>
+        <h1 className="font-serif text-2xl leading-tight">{title}</h1>
+        <p className="text-sm leading-relaxed text-muted-foreground">
+          {message}
+        </p>
+      </div>
+    </GuestShell>
+  );
+}
+
+// ============================================================
+// Hero
+// ============================================================
 
 function EventInfoHeader({
   event,
@@ -33,57 +61,54 @@ function EventInfoHeader({
   inviterName: string;
 }) {
   return (
-    <div className="flex flex-col gap-4 pb-8">
-      <h1 className="text-3xl font-light tracking-wide">{event.name}</h1>
-      <div className="flex flex-col gap-1 text-muted-foreground">
-        <p>{inviterName} さんからの招待</p>
-        <p>{formatDatetime(event.startDatetime)}</p>
-        <p>{event.venue}</p>
-        {event.openDatetime && <p>開場: {formatTime(event.openDatetime)}</p>}
+    <header className="flex flex-col gap-8">
+      <div className="flex flex-col gap-2 animate-in fade-in slide-in-from-bottom-2 duration-700 motion-reduce:animate-none">
+        <p className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+          You are invited
+        </p>
+        <h1 className="font-serif text-3xl leading-[1.3] sm:text-4xl">
+          {event.name}
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          {inviterName} さんからの招待
+        </p>
       </div>
-    </div>
+
+      <dl className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-4 border-t border-border/50 pt-6 animate-in fade-in slide-in-from-bottom-2 duration-700 delay-150 motion-reduce:animate-none motion-reduce:delay-0">
+        <dt className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+          日時
+        </dt>
+        <dd className="text-sm tabular-nums">
+          {formatDatetime(event.startDatetime)}
+        </dd>
+        {event.openDatetime && (
+          <>
+            <dt className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+              開場
+            </dt>
+            <dd className="text-sm tabular-nums">
+              {formatTime(event.openDatetime)}
+            </dd>
+          </>
+        )}
+        <dt className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+          会場
+        </dt>
+        <dd className="text-sm">{event.venue}</dd>
+      </dl>
+    </header>
   );
 }
 
-function CurrentResponseView({
-  invitation,
-}: {
-  invitation: {
-    guestName: string | null;
-    guestEmail: string | null;
-    status: string;
-    companions: {
-      id: string;
-      name: string;
-      checkedIn: boolean;
-      checkedInAt: number | null;
-    }[];
-  };
-}) {
+// ============================================================
+// Helpers
+// ============================================================
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
-    <div className="rounded-lg border p-6">
-      <h2 className="mb-4 text-lg font-light tracking-wide">現在の回答</h2>
-      <div className="flex flex-col gap-2 text-sm">
-        <p>
-          <span className="text-muted-foreground">お名前: </span>
-          {invitation.guestName}
-        </p>
-        <p>
-          <span className="text-muted-foreground">メール: </span>
-          {invitation.guestEmail}
-        </p>
-        <p>
-          <span className="text-muted-foreground">出欠: </span>
-          {invitation.status === "accepted" ? "出席" : "辞退"}
-        </p>
-        {invitation.companions.length > 0 && (
-          <div>
-            <span className="text-muted-foreground">同伴者: </span>
-            {invitation.companions.map((c) => c.name).join("、")}
-          </div>
-        )}
-      </div>
-    </div>
+    <p className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+      {children}
+    </p>
   );
 }
 
@@ -93,6 +118,57 @@ function formatCheckInTime(ts: number): string {
   const m = String(date.getMinutes()).padStart(2, "0");
   return `${h}:${m}`;
 }
+
+// ============================================================
+// Current Response
+// ============================================================
+
+function CurrentResponseView({
+  invitation,
+}: {
+  invitation: {
+    guestName: string | null;
+    guestEmail: string | null;
+    status: string;
+    companions: { id: string; name: string }[];
+  };
+}) {
+  return (
+    <section className="flex flex-col gap-4 border-t border-border/50 pt-6">
+      <SectionLabel>現在の回答</SectionLabel>
+      <dl className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-3">
+        <dt className="text-xs text-muted-foreground">お名前</dt>
+        <dd className="text-sm">{invitation.guestName}</dd>
+        <dt className="text-xs text-muted-foreground">メール</dt>
+        <dd className="break-all text-sm">{invitation.guestEmail}</dd>
+        <dt className="text-xs text-muted-foreground">出欠</dt>
+        <dd className="text-sm">
+          {invitation.status === "accepted" ? "出席" : "辞退"}
+        </dd>
+        {invitation.companions.length > 0 && (
+          <>
+            <dt className="text-xs text-muted-foreground">同伴者</dt>
+            <dd className="text-sm">
+              {invitation.companions.map((c) => c.name).join("、")}
+            </dd>
+          </>
+        )}
+      </dl>
+    </section>
+  );
+}
+
+// ============================================================
+// Check-in Status
+// ============================================================
+
+type CheckInRow = {
+  key: string;
+  name: string;
+  role: "self" | "companion";
+  checkedIn: boolean;
+  checkedInAt: number | null;
+};
 
 function CheckInStatusView({
   invitation,
@@ -109,54 +185,68 @@ function CheckInStatusView({
     }[];
   };
 }) {
+  const rows: CheckInRow[] = [
+    {
+      key: "self",
+      name: invitation.guestName ?? "本人",
+      role: "self",
+      checkedIn: invitation.checkedIn,
+      checkedInAt: invitation.checkedInAt,
+    },
+    ...invitation.companions.map<CheckInRow>((c) => ({
+      key: c.id,
+      name: c.name,
+      role: "companion",
+      checkedIn: c.checkedIn,
+      checkedInAt: c.checkedInAt,
+    })),
+  ];
+
   return (
-    <div className="mt-6 rounded-lg border p-6">
-      <h2 className="mb-4 text-lg font-light tracking-wide">受付状況</h2>
-      <div className="flex flex-col gap-2">
-        <div className="flex items-center gap-2 text-sm">
-          {invitation.checkedIn ? (
-            <CheckCircle
-              className="size-4 shrink-0 text-emerald-800/70"
-              weight="fill"
-            />
-          ) : (
-            <Circle className="size-4 shrink-0 text-muted-foreground" />
-          )}
-          <span className="flex-1">{invitation.guestName ?? "本人"}</span>
-          {invitation.checkedIn && invitation.checkedInAt ? (
-            <span className="text-muted-foreground text-xs">
-              {formatCheckInTime(invitation.checkedInAt)} 受付済み
+    <section className="flex flex-col gap-4 border-t border-border/50 pt-6">
+      <SectionLabel>受付状況</SectionLabel>
+      <ul>
+        {rows.map((row) => (
+          <li
+            key={row.key}
+            className="flex items-center gap-3 border-b border-border/30 py-3 last:border-b-0"
+          >
+            <span className="text-muted-foreground">
+              {row.role === "self" ? (
+                <User className="size-4" />
+              ) : (
+                <UsersThree className="size-4" />
+              )}
             </span>
-          ) : (
-            <span className="text-muted-foreground text-xs">未受付</span>
-          )}
-        </div>
-        {invitation.companions.map((c) => (
-          <div key={c.id} className="flex items-center gap-2 text-sm">
-            {c.checkedIn ? (
-              <CheckCircle
-                className="size-4 shrink-0 text-emerald-800/70"
-                weight="fill"
-              />
-            ) : (
-              <Circle className="size-4 shrink-0 text-muted-foreground" />
-            )}
-            <span className="flex-1">{c.name}</span>
-            {c.checkedIn && c.checkedInAt ? (
-              <span className="text-muted-foreground text-xs">
-                {formatCheckInTime(c.checkedInAt)} 受付済み
-              </span>
-            ) : (
-              <span className="text-muted-foreground text-xs">未受付</span>
-            )}
-          </div>
+            <span className="flex-1 text-sm">{row.name}</span>
+            <span
+              className={
+                row.checkedIn ? "text-primary" : "text-muted-foreground/50"
+              }
+            >
+              {row.checkedIn ? (
+                <CheckCircle className="size-4" weight="fill" />
+              ) : (
+                <Circle className="size-4" />
+              )}
+            </span>
+            <span className="w-20 text-right text-xs text-muted-foreground tabular-nums">
+              {row.checkedIn && row.checkedInAt
+                ? `${formatCheckInTime(row.checkedInAt)} 受付済み`
+                : "未受付"}
+            </span>
+          </li>
         ))}
-      </div>
-    </div>
+      </ul>
+    </section>
   );
 }
 
-function StatusMessage({
+// ============================================================
+// Status Note
+// ============================================================
+
+function StatusNote({
   isInvalidated,
   eventStatus,
 }: {
@@ -165,22 +255,22 @@ function StatusMessage({
 }) {
   let message: string;
   if (isInvalidated) {
-    message = "この招待は主催者により変更が制限されています。";
+    message = "この招待は主催者により変更が制限されています";
   } else if (eventStatus === "ongoing") {
-    message = "回答の変更期間は終了しました。";
+    message = "回答の変更期間は終了しました";
   } else {
-    message = "現在回答の変更はできません。";
+    message = "現在、回答の変更はできません";
   }
 
   return (
-    <div className="mt-4 rounded-md bg-muted p-4 text-sm text-muted-foreground">
+    <p className="border-t border-border/50 pt-6 text-xs tracking-wide text-muted-foreground">
       {message}
-    </div>
+    </p>
   );
 }
 
 // ============================================================
-// メインページ
+// Main
 // ============================================================
 
 export default async function InvitationResponsePage(
@@ -190,88 +280,116 @@ export default async function InvitationResponsePage(
   const invitation = await getInvitationByToken(token);
 
   if (!invitation) {
-    return <ErrorView message="この招待リンクは無効です" />;
+    return (
+      <ErrorView
+        title="招待リンクが見つかりません"
+        message="リンクに問題がある場合は、招待者にお問い合わせください"
+      />
+    );
   }
 
   const { event } = invitation;
   const isInvalidated = !!invitation.invalidatedAt;
 
   if (event.status === "draft") {
-    return <ErrorView message="現在準備中です" />;
+    return (
+      <ErrorView
+        title="現在準備中です"
+        message="イベント公開までしばらくお待ちください"
+      />
+    );
   }
 
-  // finished + accepted → イベント情報 + 現在の回答 + 受付状況を表示
+  // finished + accepted → 思い出カード
   if (event.status === "finished") {
     if (invitation.status === "accepted") {
       return (
-        <div className="mx-auto max-w-2xl px-6 py-12">
+        <GuestShell>
           <EventInfoHeader
             event={event}
             inviterName={invitation.inviterDisplayName}
           />
           <CurrentResponseView invitation={invitation} />
           <CheckInStatusView invitation={invitation} />
-          <div className="mt-4 rounded-md bg-muted p-4 text-sm text-muted-foreground">
-            このイベントは終了しました。
-          </div>
-        </div>
+          <p className="border-t border-border/50 pt-6 text-xs tracking-wide text-muted-foreground">
+            このイベントは終了しました。お越しいただきありがとうございました
+          </p>
+        </GuestShell>
       );
     }
-    return <ErrorView message="この招待リンクは期限切れです" />;
+    return (
+      <ErrorView
+        title="招待リンクの期限が切れました"
+        message="イベントはすでに終了しています"
+      />
+    );
   }
 
   // 無効化済み + pending/declined → 無効
   if (isInvalidated && invitation.status !== "accepted") {
-    return <ErrorView message="この招待リンクは無効です" />;
+    return (
+      <ErrorView
+        title="招待リンクは無効です"
+        message="リンクに問題がある場合は、招待者にお問い合わせください"
+      />
+    );
   }
 
-  // 回答変更が可能か判定
   const canModify =
     !isInvalidated &&
     event.status === "published" &&
     invitation.status !== "pending";
 
-  // 初回回答が可能か判定
   const canRespond =
     !isInvalidated &&
     invitation.status === "pending" &&
     (event.status === "published" || event.status === "ongoing");
 
-  // 受付状況を表示する条件: ongoing + accepted
   const showCheckInStatus =
     invitation.status === "accepted" && event.status === "ongoing";
 
+  const showPass =
+    invitation.status === "accepted" &&
+    (event.status === "published" || event.status === "ongoing");
+
+  const passCaption =
+    event.status === "ongoing"
+      ? "スタッフにこのコードをお見せください"
+      : "当日、受付でお見せください";
+
   return (
-    <div className="mx-auto max-w-2xl px-6 py-12">
+    <GuestShell>
       <EventInfoHeader
         event={event}
         inviterName={invitation.inviterDisplayName}
       />
 
-      {invitation.status === "accepted" && (
-        <div className="mb-8">
-          <QrCode path={`/i/${token}`} />
+      {showPass && (
+        <div className="animate-in fade-in slide-in-from-bottom-2 duration-700 delay-300 motion-reduce:animate-none motion-reduce:delay-0">
+          <QrCode
+            path={`/i/${token}`}
+            eventName={event.name}
+            eventDatetime={formatDatetime(event.startDatetime)}
+            caption={passCaption}
+          />
         </div>
       )}
+
+      {showCheckInStatus && <CheckInStatusView invitation={invitation} />}
 
       {invitation.status !== "pending" && (
         <CurrentResponseView invitation={invitation} />
       )}
 
-      {showCheckInStatus && <CheckInStatusView invitation={invitation} />}
-
       {(canRespond || canModify) && (
-        <div className="mt-8">
+        <div className="border-t border-border/50 pt-8">
           <InvitationResponseForm token={token} invitation={invitation} />
         </div>
       )}
 
       {!canRespond && !canModify && invitation.status !== "pending" && (
-        <StatusMessage
-          isInvalidated={isInvalidated}
-          eventStatus={event.status}
-        />
+        <StatusNote isInvalidated={isInvalidated} eventStatus={event.status} />
       )}
-    </div>
+    </GuestShell>
   );
 }


### PR DESCRIPTION
## Summary

- ピアノ発表会に招待されたゲストが `/i/[token]` で受ける体験を、lull のデザイン土台（生成り + Noto Serif JP + Shippori Mincho）の上で「招待状 → 当日のパス」という一本の流れとして再構成
- 既存のデザイントークンを活かして、一般的な shadcn の既定見た目から、明朝と uppercase ラベルによる静謐な「手紙」の手触りへ寄せた
- DB スキーマ / Server Action / ルーティングは触らず、UI のみで完結

## 変更内容

### Hero
- font-serif ディスプレイ + `uppercase tracking-[0.2em]` の補助ラベル
- メタ情報（日時 / 開場 / 会場）を `<dl>` + 罫線で階層化
- 初回マウント時のフェード + スライド、`motion-reduce:animate-none` をセット

### Admission Pass
- accept 後の QR を「紙のカード」として `border-border/50` で囲み、ADMISSION PASS ラベル + イベント名 + 日時 + キャプションを表示
- `qr-code.tsx` に `eventName / eventDatetime / caption` を optional で追加（`path` 単独呼び出しの後方互換は維持）
- ongoing では Hero 直下、published では Form 手前に配置を出し分け

### RSVP フォーム
- 出欠選択をカード式ラジオへ。`<input type=\"radio\">` を `sr-only` で隠して `<label>` でラップし、`:has(input:checked)` + `focus-within:ring-*` でネイティブ a11y を維持
- `<fieldset disabled={isPending}>` で送信中に全体を非活性化
- 回答済みの場合は自動で折りたたみ、「回答を変更する」ボタンで再展開
- 送信成功時は自動クローズ + 「回答を受け取りました」を inline アニメーションで表示

### 受付状況 / 現在の回答
- 緑 emerald のチェックを廃止し、`--primary`（朱）に統一
- 行セパレータで整理し、時刻は `tabular-nums` で右寄せ

### エラー / 状態メッセージ
- `GuestShell` + `font-serif` タイトルに統一し、draft / invalidated / expired / closed を同じテンプレートに集約
- セーフエリア（`pt-[max(2.5rem,env(safe-area-inset-top))]` 等）をシェル側で吸収

## Test plan

- [ ] `pnpm type-check` / `pnpm lint` が pass
- [ ] `/i/<token>` を下記状態で目視確認
  - [ ] published × pending（初回回答フォーム）
  - [ ] published × accepted（Pass + CurrentResponse + 折りたたみフォーム）
  - [ ] published × declined（CurrentResponse + 折りたたみフォーム、Pass なし）
  - [ ] ongoing × accepted（Pass 最上位 + CheckInStatus + 折りたたみフォームは出ない = StatusNote）
  - [ ] ongoing × declined（CurrentResponse + StatusNote）
  - [ ] finished × accepted（EventInfo + CurrentResponse + CheckInStatus + 終了メッセージ）
  - [ ] finished × pending/declined（期限切れエラー）
  - [ ] invalidated × pending/declined（無効エラー）
  - [ ] draft（準備中エラー）
- [ ] キーボード操作: 出欠カードを Tab 移動・Space/Enter で選択できる
- [ ] `prefers-reduced-motion: reduce` でモーションが止まる
- [ ] モバイル幅（iPhone 14 Pro プリセット）で縦リズムが崩れない

🤖 Generated with [Claude Code](https://claude.com/claude-code)