### PR TITLE
feat(performer): /join/[token] を招待状トーンに整え、OAuth 戻り後は自動参加

### DIFF
--- a/src/app/_components/join-event-form.tsx
+++ b/src/app/_components/join-event-form.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import { acceptPerformerInvitation } from "@/app/join/[token]/_actions";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { authClient } from "@/lib/auth-client";
 import { sessionStorageKeys } from "@/lib/hooks/storage-keys";
 import { useSessionStorage } from "@/lib/hooks/use-session-storage";
@@ -20,10 +19,16 @@ export function JoinEventForm({
   defaultDisplayName,
   isAuthenticated,
 }: JoinEventFormProps) {
-  const key = sessionStorageKeys.joinDisplayName(token);
+  const displayNameKey = sessionStorageKeys.joinDisplayName(token);
+  const pendingKey = sessionStorageKeys.joinPending(token);
+
   const [savedDisplayName, setSavedDisplayName] = useSessionStorage(
-    key,
+    displayNameKey,
     defaultDisplayName,
+  );
+  const [pendingFlag, setPendingFlag, removePendingFlag] = useSessionStorage(
+    pendingKey,
+    "",
   );
 
   const [displayName, setDisplayName] = useState(
@@ -31,10 +36,11 @@ export function JoinEventForm({
   );
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const autoJoinTriggered = useRef(false);
 
-  const handleJoinAuthenticated = () => {
+  const submitJoin = (name: string) => {
     startTransition(async () => {
-      const result = await acceptPerformerInvitation(token, displayName);
+      const result = await acceptPerformerInvitation(token, name);
       if (result?.error) {
         setError(result.error);
       }
@@ -42,8 +48,40 @@ export function JoinEventForm({
     });
   };
 
+  // OAuth 戻り直後の自動参加
+  // ref ガードで重複実行を防ぐため、deps が変動しても初回 1 度だけ submit される
+  useEffect(() => {
+    if (autoJoinTriggered.current) return;
+    if (!isAuthenticated) return;
+    if (pendingFlag !== "true") return;
+
+    autoJoinTriggered.current = true;
+    removePendingFlag();
+    const name = (savedDisplayName ?? defaultDisplayName).trim();
+    if (!name) return;
+
+    startTransition(async () => {
+      const result = await acceptPerformerInvitation(token, name);
+      if (result?.error) {
+        setError(result.error);
+      }
+    });
+  }, [
+    isAuthenticated,
+    pendingFlag,
+    savedDisplayName,
+    defaultDisplayName,
+    removePendingFlag,
+    token,
+  ]);
+
+  const handleJoinAuthenticated = () => {
+    submitJoin(displayName);
+  };
+
   const handleJoinWithGoogle = () => {
     setSavedDisplayName(displayName);
+    setPendingFlag("true");
     const target = `/join/${token}`;
     if (process.env.NEXT_PUBLIC_VERCEL_ENV === "preview") {
       authClient.signIn.oauth2({
@@ -58,10 +96,18 @@ export function JoinEventForm({
     });
   };
 
+  const isAutoJoining =
+    isAuthenticated && (pendingFlag === "true" || autoJoinTriggered.current);
+
   return (
-    <div className="space-y-6">
+    <div className="flex flex-col gap-6">
       <div className="flex flex-col gap-2">
-        <Label htmlFor="displayName">表示名</Label>
+        <label
+          htmlFor="displayName"
+          className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground"
+        >
+          Display Name
+        </label>
         <Input
           type="text"
           id="displayName"
@@ -69,6 +115,7 @@ export function JoinEventForm({
           onChange={(e) => setDisplayName(e.target.value)}
           maxLength={50}
           required
+          disabled={isAutoJoining || isPending}
         />
         <p className="text-xs text-muted-foreground">
           プログラムに表示される名前です。あとで変更できます
@@ -76,24 +123,24 @@ export function JoinEventForm({
       </div>
 
       {error && (
-        <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+        <p className="border-l-2 border-destructive pl-3 text-sm text-destructive">
           {error}
-        </div>
+        </p>
       )}
 
       {isAuthenticated ? (
         <Button
           onClick={handleJoinAuthenticated}
-          disabled={isPending || !displayName.trim()}
-          className="w-full tracking-wider"
+          disabled={isPending || isAutoJoining || !displayName.trim()}
+          className="w-full tracking-[0.18em]"
         >
-          {isPending ? "参加処理中..." : "参加する"}
+          {isPending || isAutoJoining ? "参加処理中..." : "参加する"}
         </Button>
       ) : (
         <Button
           onClick={handleJoinWithGoogle}
           disabled={!displayName.trim()}
-          className="w-full tracking-wider"
+          className="w-full tracking-[0.18em]"
         >
           Google アカウントで参加する
         </Button>

--- a/src/app/_components/join-event-form.tsx
+++ b/src/app/_components/join-event-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, useTransition } from "react";
+import { useCallback, useEffect, useRef, useState, useTransition } from "react";
 import { acceptPerformerInvitation } from "@/app/join/[token]/_actions";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -38,15 +38,19 @@ export function JoinEventForm({
   const [isPending, startTransition] = useTransition();
   const autoJoinTriggered = useRef(false);
 
-  const submitJoin = (name: string) => {
-    startTransition(async () => {
-      const result = await acceptPerformerInvitation(token, name);
-      if (result?.error) {
-        setError(result.error);
-      }
-      // 成功時は redirect されるため、ここには到達しない
-    });
-  };
+  const submitJoin = useCallback(
+    (name: string) => {
+      startTransition(async () => {
+        setError(null);
+        const result = await acceptPerformerInvitation(token, name);
+        if (result?.error) {
+          setError(result.error);
+        }
+        // 成功時は redirect されるため、ここには到達しない
+      });
+    },
+    [token],
+  );
 
   // OAuth 戻り直後の自動参加
   // ref ガードで重複実行を防ぐため、deps が変動しても初回 1 度だけ submit される
@@ -60,19 +64,14 @@ export function JoinEventForm({
     const name = (savedDisplayName ?? defaultDisplayName).trim();
     if (!name) return;
 
-    startTransition(async () => {
-      const result = await acceptPerformerInvitation(token, name);
-      if (result?.error) {
-        setError(result.error);
-      }
-    });
+    submitJoin(name);
   }, [
     isAuthenticated,
     pendingFlag,
     savedDisplayName,
     defaultDisplayName,
     removePendingFlag,
-    token,
+    submitJoin,
   ]);
 
   const handleJoinAuthenticated = () => {
@@ -96,9 +95,6 @@ export function JoinEventForm({
     });
   };
 
-  const isAutoJoining =
-    isAuthenticated && (pendingFlag === "true" || autoJoinTriggered.current);
-
   return (
     <div className="flex flex-col gap-6">
       <div className="flex flex-col gap-2">
@@ -115,7 +111,7 @@ export function JoinEventForm({
           onChange={(e) => setDisplayName(e.target.value)}
           maxLength={50}
           required
-          disabled={isAutoJoining || isPending}
+          disabled={isPending}
         />
         <p className="text-xs text-muted-foreground">
           プログラムに表示される名前です。あとで変更できます
@@ -131,10 +127,10 @@ export function JoinEventForm({
       {isAuthenticated ? (
         <Button
           onClick={handleJoinAuthenticated}
-          disabled={isPending || isAutoJoining || !displayName.trim()}
+          disabled={isPending || !displayName.trim()}
           className="w-full tracking-[0.18em]"
         >
-          {isPending || isAutoJoining ? "参加処理中..." : "参加する"}
+          {isPending ? "参加処理中..." : "参加する"}
         </Button>
       ) : (
         <Button

--- a/src/app/join/[token]/page.tsx
+++ b/src/app/join/[token]/page.tsx
@@ -1,9 +1,101 @@
 import { redirect } from "next/navigation";
 import { JoinEventForm } from "@/app/_components/join-event-form";
-import { formatDatetime } from "@/lib/format";
+import { formatDatetime, formatTime } from "@/lib/format";
 import { getEventMembership } from "@/lib/queries/events";
 import { getPerformerInvitationByToken } from "@/lib/queries/members";
 import { getSession } from "@/lib/session";
+
+// ============================================================
+// Shell
+// ============================================================
+
+function JoinShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-dvh bg-background">
+      <div className="mx-auto flex max-w-md flex-col gap-10 px-6 pt-[max(2.5rem,env(safe-area-inset-top))] pb-[max(2.5rem,env(safe-area-inset-bottom))]">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ============================================================
+// Error
+// ============================================================
+
+function ErrorView({ title, message }: { title: string; message: string }) {
+  return (
+    <JoinShell>
+      <div className="mt-16 flex flex-col items-center gap-4 text-center animate-in fade-in slide-in-from-bottom-1 duration-700 motion-reduce:animate-none">
+        <p className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+          Lull
+        </p>
+        <h1 className="font-serif text-2xl leading-tight">{title}</h1>
+        <p className="text-sm leading-relaxed text-muted-foreground">
+          {message}
+        </p>
+      </div>
+    </JoinShell>
+  );
+}
+
+// ============================================================
+// Hero + EventInfo
+// ============================================================
+
+function PerformerInvitationHeader({
+  event,
+}: {
+  event: {
+    name: string;
+    venue: string;
+    startDatetime: string;
+    openDatetime: string | null;
+  };
+}) {
+  return (
+    <header className="flex flex-col gap-8">
+      <div className="flex flex-col gap-2 animate-in fade-in slide-in-from-bottom-1 duration-500 motion-reduce:animate-none">
+        <p className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+          Performer Invitation
+        </p>
+        <h1 className="font-serif text-3xl leading-[1.3] sm:text-4xl">
+          {event.name}
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          出演者として招待されています
+        </p>
+      </div>
+
+      <dl className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-4 border-t border-border/50 pt-6 animate-in fade-in slide-in-from-bottom-1 duration-500 delay-100 fill-mode-both motion-reduce:animate-none motion-reduce:delay-0">
+        <dt className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+          日時
+        </dt>
+        <dd className="text-sm tabular-nums">
+          {formatDatetime(event.startDatetime)}
+        </dd>
+        {event.openDatetime && (
+          <>
+            <dt className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+              開場
+            </dt>
+            <dd className="text-sm tabular-nums">
+              {formatTime(event.openDatetime)}
+            </dd>
+          </>
+        )}
+        <dt className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+          会場
+        </dt>
+        <dd className="text-sm">{event.venue}</dd>
+      </dl>
+    </header>
+  );
+}
+
+// ============================================================
+// Main
+// ============================================================
 
 export default async function JoinPage(props: PageProps<"/join/[token]">) {
   const { token } = await props.params;
@@ -11,17 +103,32 @@ export default async function JoinPage(props: PageProps<"/join/[token]">) {
 
   // トークンが存在しない
   if (!invitation) {
-    return <ErrorView message="この招待リンクは無効です" />;
+    return (
+      <ErrorView
+        title="この招待リンクは無効です"
+        message="リンクに問題がある場合は、招待者にお問い合わせください"
+      />
+    );
   }
 
   // 無効化済みトークン
   if (invitation.status === "invalidated") {
-    return <ErrorView message="この招待リンクは無効です" />;
+    return (
+      <ErrorView
+        title="この招待リンクは無効です"
+        message="リンクに問題がある場合は、招待者にお問い合わせください"
+      />
+    );
   }
 
   // イベントが finished → 期限切れ
   if (invitation.event.status === "finished") {
-    return <ErrorView message="この招待リンクは期限切れです" />;
+    return (
+      <ErrorView
+        title="この招待リンクは期限切れです"
+        message="イベントはすでに終了しています"
+      />
+    );
   }
 
   const session = await getSession();
@@ -33,7 +140,12 @@ export default async function JoinPage(props: PageProps<"/join/[token]">) {
       redirect(`/events/${invitation.event.id}`);
     }
     // 別ユーザーまたは未認証 → エラー
-    return <ErrorView message="この招待リンクは既に使用済みです" />;
+    return (
+      <ErrorView
+        title="この招待リンクは既に使用済みです"
+        message="心当たりがない場合は、招待者にお問い合わせください"
+      />
+    );
   }
 
   // --- ここから status === "pending" ---
@@ -51,65 +163,15 @@ export default async function JoinPage(props: PageProps<"/join/[token]">) {
   }
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center px-6">
-      <div className="w-full max-w-md space-y-8">
-        <div className="text-center space-y-2">
-          <h1 className="font-serif text-3xl font-light tracking-wide">
-            {invitation.event.name}
-          </h1>
-          <p className="text-sm text-muted-foreground leading-relaxed">
-            出演者として招待されています
-          </p>
-        </div>
-
-        <div className="rounded-sm border border-border/50 bg-card p-6 space-y-4">
-          <div>
-            <p className="text-xs tracking-[0.2em] uppercase text-muted-foreground">
-              開催日時
-            </p>
-            <p className="leading-relaxed">
-              {formatDatetime(invitation.event.startDatetime)}
-            </p>
-          </div>
-          {invitation.event.openDatetime && (
-            <div>
-              <p className="text-xs tracking-[0.2em] uppercase text-muted-foreground">
-                開場
-              </p>
-              <p className="leading-relaxed">
-                {formatDatetime(invitation.event.openDatetime)}
-              </p>
-            </div>
-          )}
-          <div>
-            <p className="text-xs tracking-[0.2em] uppercase text-muted-foreground">
-              会場
-            </p>
-            <p className="leading-relaxed">{invitation.event.venue}</p>
-          </div>
-        </div>
-
+    <JoinShell>
+      <PerformerInvitationHeader event={invitation.event} />
+      <div className="border-t border-border/50 pt-8 animate-in fade-in slide-in-from-bottom-1 duration-500 delay-200 fill-mode-both motion-reduce:animate-none motion-reduce:delay-0">
         <JoinEventForm
           token={token}
           defaultDisplayName={invitation.displayName}
           isAuthenticated={!!session}
         />
       </div>
-    </div>
-  );
-}
-
-function ErrorView({ message }: { message: string }) {
-  return (
-    <div className="flex min-h-screen flex-col items-center justify-center px-6">
-      <div className="text-center space-y-4">
-        <h1 className="font-serif text-2xl font-light tracking-wide">
-          {message}
-        </h1>
-        <p className="text-sm text-muted-foreground leading-relaxed">
-          リンクに問題がある場合は、招待者にお問い合わせください
-        </p>
-      </div>
-    </div>
+    </JoinShell>
   );
 }

--- a/src/lib/hooks/storage-keys.ts
+++ b/src/lib/hooks/storage-keys.ts
@@ -17,4 +17,7 @@ export const sessionStorageKeys = {
   /** /join/[token] で OAuth 前に保存する表示名 */
   joinDisplayName: (token: string): StorageKey<string> =>
     `join:${token}:displayName` as StorageKey<string>,
+  /** /join/[token] で OAuth 開始時に立てる「戻ったら自動参加」フラグ */
+  joinPending: (token: string): StorageKey<string> =>
+    `join:${token}:pending` as StorageKey<string>,
 } as const;


### PR DESCRIPTION
## Summary

- `/join/[token]` を `/i/[token]` と同じ招待状トーン（`JoinShell` + `Performer Invitation` ラベル + 罫線区切りエディトリアル）に再構成
- スタッガーアニメを `slide-in-from-bottom-1 / duration-500 / fill-mode-both` に弱め、初期描画のチラつきを緩和
- `JoinEventForm`: Google ログインボタンを押した時点で sessionStorage に `pending` フラグを保存。OAuth 戻り後に `isAuthenticated && pending === true` なら自動で `acceptPerformerInvitation` を呼ぶ（`useRef` で重複実行ガード、フラグは即削除）
- 直接 `/join/<token>` を踏んだだけでは自動参加せず、従来通り手動ボタン

## Test plan

- [x] `pnpm type-check` 通過
- [x] `pnpm lint` 通過
- [ ] dev で未ログイン → Google ログイン → 戻り直後にボタン押下なしで参加処理が走り `/events/<id>` にリダイレクトされる
- [ ] ログイン済みユーザーで直接 `/join/<token>` を開いたとき、自動参加せず「参加する」ボタンが出る
- [ ] 自動参加中は input/button が disabled、ラベルが「参加処理中...」になる
- [ ] 自動参加が失敗（無効トークン等）した場合、エラーが罫線スタイルで表示され、フラグが消えていて手動リトライ可能
- [ ] スタッガーが順に開き、初期描画でチラつかない
- [ ] `prefers-reduced-motion: reduce` でアニメが停止する
- [ ] モバイル幅でセーフエリアが効いている

🤖 Generated with [Claude Code](https://claude.com/claude-code)