### PR TITLE
refactor(ui): unify form feedback with sonner toast

### DIFF
--- a/src/app/_components/create-event-form.tsx
+++ b/src/app/_components/create-event-form.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useActionState } from "react";
+import { toast } from "sonner";
 import {
   type CreateEventState,
   createEvent,
@@ -14,7 +15,13 @@ export function CreateEventForm() {
   const [state, formAction, isPending] = useActionState<
     CreateEventState,
     FormData
-  >(createEvent, null);
+  >(async (prevState, formData) => {
+    const result = await createEvent(prevState, formData);
+    if (result?.error) {
+      toast.error(result.error);
+    }
+    return result;
+  }, null);
 
   const f = state?.fields;
 
@@ -25,12 +32,6 @@ export function CreateEventForm() {
       </h2>
 
       <form action={formAction} className="flex flex-col gap-6">
-        {state?.error && (
-          <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-            {state.error}
-          </div>
-        )}
-
         <div className="flex flex-col gap-2">
           <Label htmlFor="name">イベント名</Label>
           <Input

--- a/src/app/_components/create-invitation-button.tsx
+++ b/src/app/_components/create-invitation-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useRef, useState, useTransition } from "react";
+import { useRef, useTransition } from "react";
+import { toast } from "sonner";
 import { createGuestInvitation } from "@/app/(main)/events/[eventId]/invitations/_actions";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -8,16 +9,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
 export function CreateInvitationButton({ eventId }: { eventId: string }) {
-  const [error, setError] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
   const [isPending, startTransition] = useTransition();
   const formRef = useRef<HTMLFormElement>(null);
-
-  useEffect(() => {
-    if (!copied) return;
-    const id = setTimeout(() => setCopied(false), 2000);
-    return () => clearTimeout(id);
-  }, [copied]);
 
   const handleSubmit = (formData: FormData) => {
     const guestName = formData.get("guestName") as string | undefined;
@@ -27,18 +20,17 @@ export function CreateInvitationButton({ eventId }: { eventId: string }) {
         guestName || undefined,
       );
       if ("error" in result) {
-        setError(result.error);
-      } else {
-        setError(null);
-        const url = `${window.location.origin}/i/${result.token}`;
-        try {
-          await navigator.clipboard.writeText(url);
-          setCopied(true);
-        } catch {
-          setError(`クリップボードへのコピーに失敗しました。URL: ${url}`);
-        }
-        formRef.current?.reset();
+        toast.error(result.error);
+        return;
       }
+      const url = `${window.location.origin}/i/${result.token}`;
+      try {
+        await navigator.clipboard.writeText(url);
+        toast.success("招待リンクをコピーしました");
+      } catch {
+        toast.error(`クリップボードへのコピーに失敗しました。URL: ${url}`);
+      }
+      formRef.current?.reset();
     });
   };
 
@@ -55,11 +47,6 @@ export function CreateInvitationButton({ eventId }: { eventId: string }) {
           action={handleSubmit}
           className="flex flex-col gap-4"
         >
-          {error && (
-            <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-              {error}
-            </div>
-          )}
           <div className="flex flex-col gap-2">
             <Label htmlFor="inviteGuestName">ゲスト名（任意）</Label>
             <Input
@@ -74,11 +61,6 @@ export function CreateInvitationButton({ eventId }: { eventId: string }) {
             <Button type="submit" disabled={isPending}>
               {isPending ? "発行中..." : "招待リンクを発行"}
             </Button>
-            {copied && (
-              <span className="text-sm text-muted-foreground">
-                リンクをコピーしました
-              </span>
-            )}
           </div>
         </form>
       </CardContent>

--- a/src/app/_components/event-detail.tsx
+++ b/src/app/_components/event-detail.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useActionState, useState, useTransition } from "react";
+import { toast } from "sonner";
 import {
   deleteEvent,
   updateEvent,
@@ -57,10 +58,21 @@ export function EventDetail({
   availableTransitions,
 }: EventDetailProps) {
   const [isEditing, setIsEditing] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
-  const [editState, editAction, isEditPending] = useActionState(
-    updateEvent.bind(null, event.id),
+  const [, editAction, isEditPending] = useActionState(
+    async (
+      prevState: Awaited<ReturnType<typeof updateEvent>> | null,
+      formData: FormData,
+    ) => {
+      const result = await updateEvent(event.id, prevState, formData);
+      if (result && "error" in result) {
+        toast.error(result.error);
+      } else if (result && "event" in result) {
+        toast.success("イベントを更新しました");
+        setIsEditing(false);
+      }
+      return result;
+    },
     null,
   );
   const isOrganizer = currentUserRole === "organizer";
@@ -71,7 +83,9 @@ export function EventDetail({
     startTransition(async () => {
       const result = await updateEventStatus(event.id, newStatus);
       if (result?.error) {
-        setError(result.error);
+        toast.error(result.error);
+      } else {
+        toast.success("ステータスを変更しました");
       }
     });
   };
@@ -80,8 +94,9 @@ export function EventDetail({
     startTransition(async () => {
       const result = await deleteEvent(event.id);
       if (result?.error) {
-        setError(result.error);
+        toast.error(result.error);
       }
+      // 成功時は redirect されるため、ここには到達しない
     });
   };
 
@@ -103,12 +118,6 @@ export function EventDetail({
           </Button>
         )}
       </div>
-
-      {error && (
-        <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-          {error}
-        </div>
-      )}
 
       {/* イベント情報 — 閲覧モード */}
       {!isEditing && (
@@ -158,11 +167,6 @@ export function EventDetail({
           </h2>
 
           <form action={editAction} className="flex flex-col gap-6">
-            {editState?.error && (
-              <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-                {editState.error}
-              </div>
-            )}
             <div className="flex flex-col gap-2">
               <Label htmlFor="name">イベント名</Label>
               <Input

--- a/src/app/_components/invitation-list.tsx
+++ b/src/app/_components/invitation-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState, useTransition } from "react";
+import { useTransition } from "react";
+import { toast } from "sonner";
 import {
   deleteInvitation,
   invalidateInvitation,
@@ -132,14 +133,6 @@ function InvitationRow({
   isOrganizer: boolean;
 }) {
   const [isPending, startTransition] = useTransition();
-  const [error, setError] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
-
-  useEffect(() => {
-    if (!copied) return;
-    const id = setTimeout(() => setCopied(false), 2000);
-    return () => clearTimeout(id);
-  }, [copied]);
 
   const isInvalidated = !!invitation.invalidatedAt;
   const canInvalidate =
@@ -157,9 +150,9 @@ function InvitationRow({
     const url = `${window.location.origin}/i/${invitation.token}`;
     try {
       await navigator.clipboard.writeText(url);
-      setCopied(true);
+      toast.success("リンクをコピーしました");
     } catch {
-      setError(`クリップボードへのコピーに失敗しました。URL: ${url}`);
+      toast.error(`クリップボードへのコピーに失敗しました。URL: ${url}`);
     }
   };
 
@@ -167,7 +160,9 @@ function InvitationRow({
     startTransition(async () => {
       const result = await invalidateInvitation(eventId, invitation.id);
       if (result?.error) {
-        setError(result.error);
+        toast.error(result.error);
+      } else {
+        toast.success("招待を無効化しました");
       }
     });
   };
@@ -176,7 +171,9 @@ function InvitationRow({
     startTransition(async () => {
       const result = await deleteInvitation(eventId, invitation.id);
       if (result?.error) {
-        setError(result.error);
+        toast.error(result.error);
+      } else {
+        toast.success("招待を削除しました");
       }
     });
   };
@@ -185,7 +182,9 @@ function InvitationRow({
     startTransition(async () => {
       const result = await proxyChangeStatus(eventId, invitation.id, newStatus);
       if (result?.error) {
-        setError(result.error);
+        toast.error(result.error);
+      } else {
+        toast.success("出欠を変更しました");
       }
     });
   };
@@ -237,16 +236,10 @@ function InvitationRow({
         </Collapsible>
       )}
 
-      {error && (
-        <div className="rounded-md bg-destructive/10 p-2 text-sm text-destructive">
-          {error}
-        </div>
-      )}
-
       <div className="flex flex-wrap items-center gap-2">
         {canCopyLink && (
           <Button variant="outline" size="sm" onClick={handleCopyLink}>
-            {copied ? "コピーしました" : "リンクをコピー"}
+            リンクをコピー
           </Button>
         )}
 

--- a/src/app/_components/invitation-response-form.tsx
+++ b/src/app/_components/invitation-response-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import { toast } from "sonner";
 import { respondToInvitation } from "@/app/i/[token]/_actions";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -43,10 +44,8 @@ export function InvitationResponseForm({
         }))
       : [],
   );
-  const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [isPending, startTransition] = useTransition();
-  const [success, setSuccess] = useState(false);
   const [isOpen, setIsOpen] = useState(!isUpdate);
 
   const handleAddCompanion = () => {
@@ -66,9 +65,7 @@ export function InvitationResponseForm({
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    setError(null);
     setFieldErrors({});
-    setSuccess(false);
 
     startTransition(async () => {
       const result = await respondToInvitation(token, {
@@ -82,10 +79,10 @@ export function InvitationResponseForm({
       });
 
       if (result) {
-        if (result.error) setError(result.error);
         if (result.fieldErrors) setFieldErrors(result.fieldErrors);
+        if (result.error) toast.error(result.error);
       } else {
-        setSuccess(true);
+        toast.success("回答を受け取りました");
         setIsOpen(false);
       }
     });
@@ -101,18 +98,10 @@ export function InvitationResponseForm({
           <h2 className="font-serif text-2xl leading-tight">
             回答は送信済みです
           </h2>
-          {success && (
-            <p className="mt-3 font-serif text-sm text-accent-foreground animate-in fade-in slide-in-from-top-1 duration-500 motion-reduce:animate-none">
-              回答を受け取りました
-            </p>
-          )}
         </div>
         <button
           type="button"
-          onClick={() => {
-            setSuccess(false);
-            setIsOpen(true);
-          }}
+          onClick={() => setIsOpen(true)}
           className="self-start rounded-sm px-1 py-1 text-sm underline underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
           回答を変更する
@@ -130,16 +119,6 @@ export function InvitationResponseForm({
         <h2 className="font-serif text-2xl leading-tight">
           {isUpdate ? "回答を変更する" : "出欠をお聞かせください"}
         </h2>
-        {success && (
-          <p className="mt-3 font-serif text-sm text-accent-foreground animate-in fade-in slide-in-from-top-1 duration-500 motion-reduce:animate-none">
-            回答を受け取りました
-          </p>
-        )}
-        {error && (
-          <p className="mt-3 border-t border-destructive/30 pt-3 text-sm text-destructive">
-            {error}
-          </p>
-        )}
       </div>
 
       <fieldset

--- a/src/app/_components/invite-performer-form.tsx
+++ b/src/app/_components/invite-performer-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useRef, useState, useTransition } from "react";
+import { useRef, useTransition } from "react";
+import { toast } from "sonner";
 import { createPerformerInvitation } from "@/app/(main)/events/[eventId]/members/_actions";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -8,30 +9,23 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
 export function InvitePerformerForm({ eventId }: { eventId: string }) {
-  const [error, setError] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
   const [isPending, startTransition] = useTransition();
   const formRef = useRef<HTMLFormElement>(null);
-
-  useEffect(() => {
-    if (!copied) return;
-    const id = setTimeout(() => setCopied(false), 2000);
-    return () => clearTimeout(id);
-  }, [copied]);
 
   const handleSubmit = (formData: FormData) => {
     startTransition(async () => {
       const result = await createPerformerInvitation(eventId, null, formData);
       if (result && "error" in result) {
-        setError(result.error);
-      } else if (result && "token" in result) {
-        setError(null);
+        toast.error(result.error);
+        return;
+      }
+      if (result && "token" in result) {
         const url = `${window.location.origin}/join/${result.token}`;
         try {
           await navigator.clipboard.writeText(url);
-          setCopied(true);
+          toast.success("招待リンクをコピーしました");
         } catch {
-          setError(`クリップボードへのコピーに失敗しました。URL: ${url}`);
+          toast.error(`クリップボードへのコピーに失敗しました。URL: ${url}`);
         }
         formRef.current?.reset();
       }
@@ -51,11 +45,6 @@ export function InvitePerformerForm({ eventId }: { eventId: string }) {
           action={handleSubmit}
           className="flex flex-col gap-4"
         >
-          {error && (
-            <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-              {error}
-            </div>
-          )}
           <div className="flex flex-col gap-2">
             <Label htmlFor="inviteDisplayName">表示名</Label>
             <Input
@@ -71,11 +60,6 @@ export function InvitePerformerForm({ eventId }: { eventId: string }) {
             <Button type="submit" disabled={isPending}>
               {isPending ? "発行中..." : "招待リンクを発行"}
             </Button>
-            {copied && (
-              <span className="text-sm text-muted-foreground">
-                リンクをコピーしました
-              </span>
-            )}
           </div>
         </form>
       </CardContent>

--- a/src/app/_components/join-event-form.tsx
+++ b/src/app/_components/join-event-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState, useTransition } from "react";
+import { toast } from "sonner";
 import { acceptPerformerInvitation } from "@/app/join/[token]/_actions";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -34,17 +35,15 @@ export function JoinEventForm({
   const [displayName, setDisplayName] = useState(
     savedDisplayName ?? defaultDisplayName,
   );
-  const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
   const autoJoinTriggered = useRef(false);
 
   const submitJoin = useCallback(
     (name: string) => {
       startTransition(async () => {
-        setError(null);
         const result = await acceptPerformerInvitation(token, name);
         if (result?.error) {
-          setError(result.error);
+          toast.error(result.error);
         }
         // 成功時は redirect されるため、ここには到達しない
       });
@@ -117,12 +116,6 @@ export function JoinEventForm({
           プログラムに表示される名前です。あとで変更できます
         </p>
       </div>
-
-      {error && (
-        <p className="border-l-2 border-destructive pl-3 text-sm text-destructive">
-          {error}
-        </p>
-      )}
 
       {isAuthenticated ? (
         <Button

--- a/src/app/_components/member-list.tsx
+++ b/src/app/_components/member-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import { toast } from "sonner";
 import {
   removeMember,
   updateDisplayName,
@@ -53,7 +54,6 @@ export function MemberList({
   isOrganizer: boolean;
   canModify: boolean;
 }) {
-  const [error, setError] = useState<string | null>(null);
   const [pendingId, setPendingId] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
@@ -67,9 +67,9 @@ export function MemberList({
     startTransition(async () => {
       const result = await removeMember(eventId, memberId);
       if (result?.error) {
-        setError(result.error);
+        toast.error(result.error);
       } else {
-        setError(null);
+        toast.success("メンバーを削除しました");
       }
       setPendingId(null);
     });
@@ -90,11 +90,6 @@ export function MemberList({
         </CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-0">
-        {error && (
-          <div className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-            {error}
-          </div>
-        )}
         {sorted.map((member, index) => (
           <div key={member.id}>
             {index > 0 && <Separator />}
@@ -177,16 +172,15 @@ function EditDisplayNameDialog({
   currentDisplayName: string;
 }) {
   const [open, setOpen] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
   const handleSubmit = (formData: FormData) => {
     startTransition(async () => {
       const result = await updateDisplayName(eventId, null, formData);
       if (result?.error) {
-        setError(result.error);
+        toast.error(result.error);
       } else {
-        setError(null);
+        toast.success("表示名を変更しました");
         setOpen(false);
       }
     });
@@ -204,11 +198,6 @@ function EditDisplayNameDialog({
           <DialogTitle>表示名を変更</DialogTitle>
         </DialogHeader>
         <form action={handleSubmit} className="flex flex-col gap-4">
-          {error && (
-            <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-              {error}
-            </div>
-          )}
           <div className="flex flex-col gap-2">
             <Label htmlFor="displayName">表示名</Label>
             <Input

--- a/src/app/_components/performer-invitation-list.tsx
+++ b/src/app/_components/performer-invitation-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useState, useTransition } from "react";
+import { toast } from "sonner";
 import {
   deletePerformerInvitation,
   invalidatePerformerInvitation,
@@ -36,9 +37,7 @@ export function PerformerInvitationList({
   eventStatus: EventStatus;
   invitations: PerformerInvitationItem[];
 }) {
-  const [error, setError] = useState<string | null>(null);
   const [pendingId, setPendingId] = useState<string | null>(null);
-  const [copiedId, setCopiedId] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
   const canInvalidate =
@@ -46,28 +45,24 @@ export function PerformerInvitationList({
     eventStatus === "published" ||
     eventStatus === "ongoing";
 
-  const handleCopy = useCallback(
-    async (invitationId: string, token: string) => {
-      try {
-        const url = `${window.location.origin}/join/${token}`;
-        await navigator.clipboard.writeText(url);
-        setCopiedId(invitationId);
-        setTimeout(() => setCopiedId(null), 2000);
-      } catch {
-        setError("クリップボードへのコピーに失敗しました");
-      }
-    },
-    [],
-  );
+  const handleCopy = useCallback(async (token: string) => {
+    try {
+      const url = `${window.location.origin}/join/${token}`;
+      await navigator.clipboard.writeText(url);
+      toast.success("リンクをコピーしました");
+    } catch {
+      toast.error("クリップボードへのコピーに失敗しました");
+    }
+  }, []);
 
   const handleInvalidate = (invitationId: string) => {
     setPendingId(invitationId);
     startTransition(async () => {
       const result = await invalidatePerformerInvitation(eventId, invitationId);
       if (result?.error) {
-        setError(result.error);
+        toast.error(result.error);
       } else {
-        setError(null);
+        toast.success("招待を無効化しました");
       }
       setPendingId(null);
     });
@@ -78,9 +73,9 @@ export function PerformerInvitationList({
     startTransition(async () => {
       const result = await deletePerformerInvitation(eventId, invitationId);
       if (result?.error) {
-        setError(result.error);
+        toast.error(result.error);
       } else {
-        setError(null);
+        toast.success("招待を削除しました");
       }
       setPendingId(null);
     });
@@ -94,11 +89,6 @@ export function PerformerInvitationList({
         </CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-0">
-        {error && (
-          <div className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-            {error}
-          </div>
-        )}
         {invitations.map((inv, index) => (
           <div key={inv.id}>
             {index > 0 && <Separator />}
@@ -114,9 +104,9 @@ export function PerformerInvitationList({
                   <Button
                     variant="outline"
                     size="sm"
-                    onClick={() => handleCopy(inv.id, inv.token)}
+                    onClick={() => handleCopy(inv.token)}
                   >
-                    {copiedId === inv.id ? "コピーしました" : "リンクをコピー"}
+                    リンクをコピー
                   </Button>
                 )}
                 {canInvalidate && inv.status === "pending" && (

--- a/src/app/_components/program-form.tsx
+++ b/src/app/_components/program-form.tsx
@@ -94,6 +94,8 @@ export function ProgramForm({
           setPieces([{ id: crypto.randomUUID(), title: "", composer: "" }]);
         }
         onSuccess?.();
+      } else if (result.error && !result.fieldErrors) {
+        toast.error(result.error);
       }
       return result;
     },
@@ -342,10 +344,6 @@ export function ProgramForm({
           </p>
         )}
       </div>
-
-      {state?.error && !state.fieldErrors && (
-        <p className="text-sm text-destructive">{state.error}</p>
-      )}
 
       <div className="flex justify-end">
         <Button type="submit" disabled={isPending}>

--- a/src/app/_components/program-list.tsx
+++ b/src/app/_components/program-list.tsx
@@ -75,6 +75,8 @@ export function ProgramList({
       const result = await onDelete(eventId, programId);
       if (result?.error) {
         toast.error(result.error);
+      } else {
+        toast.success("プログラムを削除しました");
       }
     });
   };


### PR DESCRIPTION
- Replace inline error boxes across forms/lists with toast.error
- Add toast.success for status changes, delete, update, and copy actions
- Remove bespoke copied/error state timers from invite/invitation components
- Keep field-level validation errors inline as they annotate specific inputs
- Keep the check-in view's dedicated error card since its re-scan flow differs

https://claude.ai/code/session_01FigRtw1qWoJTuRE3NELzz5