### PR TITLE
fix(checkin): show matched companion names in search results

### DIFF
--- a/src/app/(main)/events/[eventId]/checkin/_actions.ts
+++ b/src/app/(main)/events/[eventId]/checkin/_actions.ts
@@ -24,13 +24,20 @@ export type LookupInvitation = {
   }[];
 };
 
+export type SearchInvitationResult = LookupInvitation & {
+  /** ゲスト名が検索クエリにマッチしたか */
+  guestNameMatched: boolean;
+  /** 検索クエリにマッチした同伴者 id のリスト */
+  matchedCompanionIds: string[];
+};
+
 export type LookupResult = { error: string } | { invitation: LookupInvitation };
 
 /** 名前検索によるチェックイン用招待情報検索 */
 export async function searchInvitationByName(
   eventId: string,
   query: string,
-): Promise<{ error: string } | { invitations: LookupInvitation[] }> {
+): Promise<{ error: string } | { invitations: SearchInvitationResult[] }> {
   const session = await requireSession();
 
   // メンバー権限チェック
@@ -86,15 +93,25 @@ export async function searchInvitationByName(
     },
   });
 
+  const lower = trimmed.toLowerCase();
   return {
-    invitations: rows.map((r) => ({
-      id: r.id,
-      guestName: r.guestName,
-      guestEmail: r.guestEmail,
-      checkedIn: r.checkedIn,
-      checkedInAt: r.checkedInAt,
-      companions: r.companions,
-    })),
+    invitations: rows.map((r) => {
+      const guestNameMatched =
+        r.guestName?.toLowerCase().includes(lower) ?? false;
+      const matchedCompanionIds = r.companions
+        .filter((c) => c.name.toLowerCase().includes(lower))
+        .map((c) => c.id);
+      return {
+        id: r.id,
+        guestName: r.guestName,
+        guestEmail: r.guestEmail,
+        checkedIn: r.checkedIn,
+        checkedInAt: r.checkedInAt,
+        companions: r.companions,
+        guestNameMatched,
+        matchedCompanionIds,
+      };
+    }),
   };
 }
 

--- a/src/app/_components/app-header.tsx
+++ b/src/app/_components/app-header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ArrowLeft, List } from "@phosphor-icons/react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useHeaderConfig } from "@/app/_components/header-config";
@@ -30,11 +31,15 @@ export function AppHeader() {
           )}
         </div>
 
-        {/* 中央: ロゴ（常に中央固定） */}
+        {/* 中央: ロゴ（常に中央固定）→ タップでダッシュボードへ */}
         <div className="justify-self-center">
-          <span className="font-serif text-lg font-light tracking-widest text-primary">
+          <Link
+            href="/dashboard"
+            aria-label="ホームへ"
+            className="font-serif text-lg font-light tracking-widest text-primary"
+          >
             Lull
-          </span>
+          </Link>
         </div>
 
         {/* 右: ハンバーガーメニュー */}

--- a/src/app/_components/check-in-view.tsx
+++ b/src/app/_components/check-in-view.tsx
@@ -28,6 +28,12 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import type { EventStatus } from "@/db/schema";
 import { statusLabels, statusVariants } from "@/lib/event-status";
@@ -48,12 +54,19 @@ type CheckInViewProps = {
   initialList: CheckInListItem[];
 };
 
+/** QR スキャン結果は Dialog、名前検索・一覧選択はインラインで表示 */
+type ResultSource = "qr" | "inline";
+
 type ViewState =
   | { mode: "idle" }
   | { mode: "scanning" }
-  | { mode: "loading" }
-  | { mode: "error"; message: string }
-  | { mode: "found"; invitation: LookupInvitation };
+  | { mode: "loading"; source: ResultSource }
+  | { mode: "error"; message: string; source: ResultSource }
+  | {
+      mode: "found";
+      invitation: LookupInvitation;
+      source: ResultSource;
+    };
 
 /** スキャン結果の URL からトークンを抽出 */
 function extractToken(scannedValue: string): string | null {
@@ -92,17 +105,26 @@ export function CheckInView({
         setViewState({
           mode: "error",
           message: "QR コードからトークンを読み取れませんでした",
+          source: "qr",
         });
         return;
       }
 
-      setViewState({ mode: "loading" });
+      setViewState({ mode: "loading", source: "qr" });
 
       const result = await lookupInvitationByToken(event.id, token);
       if ("error" in result) {
-        setViewState({ mode: "error", message: result.error });
+        setViewState({
+          mode: "error",
+          message: result.error,
+          source: "qr",
+        });
       } else {
-        setViewState({ mode: "found", invitation: result.invitation });
+        setViewState({
+          mode: "found",
+          invitation: result.invitation,
+          source: "qr",
+        });
       }
     },
     [event.id],
@@ -152,8 +174,15 @@ export function CheckInView({
         targetId,
       );
 
+      const currentSource: ResultSource =
+        viewState.mode === "found" ? viewState.source : "inline";
+
       if ("error" in result) {
-        setViewState({ mode: "error", message: result.error });
+        setViewState({
+          mode: "error",
+          message: result.error,
+          source: currentSource,
+        });
         return;
       }
 
@@ -180,12 +209,19 @@ export function CheckInView({
               : c,
           );
         }
-        setViewState({ mode: "found", invitation: updated });
+        setViewState({
+          mode: "found",
+          invitation: updated,
+          source: viewState.source,
+        });
       }
     } catch {
+      const currentSource: ResultSource =
+        viewState.mode === "found" ? viewState.source : "inline";
       setViewState({
         mode: "error",
         message: "チェックイン処理中にエラーが発生しました",
+        source: currentSource,
       });
     } finally {
       setProcessing(null);
@@ -207,8 +243,15 @@ export function CheckInView({
         targetId,
       );
 
+      const currentSource: ResultSource =
+        viewState.mode === "found" ? viewState.source : "inline";
+
       if ("error" in result) {
-        setViewState({ mode: "error", message: result.error });
+        setViewState({
+          mode: "error",
+          message: result.error,
+          source: currentSource,
+        });
         return;
       }
 
@@ -227,12 +270,19 @@ export function CheckInView({
               : c,
           );
         }
-        setViewState({ mode: "found", invitation: updated });
+        setViewState({
+          mode: "found",
+          invitation: updated,
+          source: viewState.source,
+        });
       }
     } catch {
+      const currentSource: ResultSource =
+        viewState.mode === "found" ? viewState.source : "inline";
       setViewState({
         mode: "error",
         message: "取り消し処理中にエラーが発生しました",
+        source: currentSource,
       });
     } finally {
       setProcessing(null);
@@ -251,6 +301,7 @@ export function CheckInView({
       setViewState({
         mode: "error",
         message: "お使いのブラウザはカメラ機能に対応していません",
+        source: "inline",
       });
       return;
     }
@@ -276,6 +327,7 @@ export function CheckInView({
           : err instanceof Error
             ? err.message
             : "カメラの起動に失敗しました",
+        source: "inline",
       });
       return;
     } finally {
@@ -295,7 +347,11 @@ export function CheckInView({
     const result = await searchInvitationByName(event.id, searchQuery);
     setSearching(false);
     if ("error" in result) {
-      setViewState({ mode: "error", message: result.error });
+      setViewState({
+        mode: "error",
+        message: result.error,
+        source: "inline",
+      });
     } else {
       setSearchResults(result.invitations);
     }
@@ -313,6 +369,7 @@ export function CheckInView({
         checkedInAt: item.checkedInAt,
         companions: item.companions,
       },
+      source: "inline",
     });
   };
 
@@ -440,6 +497,7 @@ export function CheckInView({
                             checkedInAt: inv.checkedInAt,
                             companions: inv.companions,
                           },
+                          source: "inline",
                         })
                       }
                     >
@@ -575,148 +633,233 @@ export function CheckInView({
         </Card>
       </Collapsible>
 
-      {viewState.mode === "loading" && (
-        <div className="flex flex-col items-center gap-2 py-8">
-          <Spinner className="size-8 animate-spin" />
-          <p className="text-muted-foreground text-sm">照会中...</p>
-        </div>
-      )}
+      {/* インライン（名前検索・一覧選択）からの結果表示 */}
+      {(viewState.mode === "loading" ||
+        viewState.mode === "error" ||
+        viewState.mode === "found") &&
+        viewState.source === "inline" && (
+          <ResultPanel
+            viewState={viewState}
+            processing={processing}
+            onCheckIn={handleCheckIn}
+            onUndo={handleUndo}
+            onRescan={startScanning}
+          />
+        )}
 
-      {viewState.mode === "error" && (
-        <Card>
-          <CardContent className="flex flex-col items-center gap-4 pt-6">
-            <Warning className="text-destructive size-10" />
-            <p className="text-destructive text-center text-sm">
-              {viewState.message}
-            </p>
-            <Button variant="outline" onClick={startScanning}>
-              再スキャン
-            </Button>
-          </CardContent>
-        </Card>
-      )}
-
-      {viewState.mode === "found" && (
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">
-              {viewState.invitation.guestName ?? "名前未登録"}
-            </CardTitle>
-            {viewState.invitation.guestEmail && (
-              <p className="text-muted-foreground text-sm">
-                {viewState.invitation.guestEmail}
-              </p>
+      {/* QR スキャン結果はポップアップで表示 */}
+      <Dialog
+        open={
+          (viewState.mode === "loading" ||
+            viewState.mode === "error" ||
+            viewState.mode === "found") &&
+          viewState.source === "qr"
+        }
+        onOpenChange={(open) => {
+          if (!open) setViewState({ mode: "idle" });
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              {viewState.mode === "found"
+                ? (viewState.invitation.guestName ?? "名前未登録")
+                : viewState.mode === "error"
+                  ? "QR スキャンエラー"
+                  : "照会中"}
+            </DialogTitle>
+          </DialogHeader>
+          {(viewState.mode === "loading" ||
+            viewState.mode === "error" ||
+            viewState.mode === "found") &&
+            viewState.source === "qr" && (
+              <ResultPanel
+                viewState={viewState}
+                processing={processing}
+                onCheckIn={handleCheckIn}
+                onUndo={handleUndo}
+                onRescan={startScanning}
+                variant="dialog"
+              />
             )}
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {/* ゲスト本人 */}
-            <div className="flex min-h-14 items-center justify-between rounded-md border p-3">
-              <div className="flex items-center gap-2">
-                <User className="text-muted-foreground size-4" />
-                <span className="text-sm font-medium">本人</span>
-                {viewState.invitation.checkedIn &&
-                  viewState.invitation.checkedInAt && (
-                    <span className="text-muted-foreground text-xs">
-                      {formatTimestamp(viewState.invitation.checkedInAt)}
-                    </span>
-                  )}
-              </div>
-              {viewState.invitation.checkedIn ? (
-                <div className="flex items-center gap-2">
-                  <CheckCircle
-                    className="size-5 text-emerald-800/70"
-                    weight="fill"
-                  />
-                  <button
-                    type="button"
-                    className="text-muted-foreground text-xs underline"
-                    disabled={processing === "guest"}
-                    onClick={() => handleUndo(viewState.invitation.id, "guest")}
-                  >
-                    取り消し
-                  </button>
-                </div>
-              ) : (
-                <Button
-                  size="sm"
-                  disabled={processing === "guest"}
-                  onClick={() =>
-                    handleCheckIn(viewState.invitation.id, "guest")
-                  }
-                >
-                  チェックイン
-                </Button>
-              )}
-            </div>
-
-            {/* 同伴者 */}
-            {viewState.invitation.companions.map((companion) => (
-              <div
-                key={companion.id}
-                className="flex min-h-14 items-center justify-between rounded-md border p-3"
-              >
-                <div className="flex items-center gap-2">
-                  <Users className="text-muted-foreground size-4" />
-                  <span className="text-sm font-medium">{companion.name}</span>
-                  {companion.checkedIn && companion.checkedInAt && (
-                    <span className="text-muted-foreground text-xs">
-                      {formatTimestamp(companion.checkedInAt)}
-                    </span>
-                  )}
-                </div>
-                {companion.checkedIn ? (
-                  <div className="flex items-center gap-2">
-                    <CheckCircle
-                      className="size-5 text-emerald-800/70"
-                      weight="fill"
-                    />
-                    <button
-                      type="button"
-                      className="text-muted-foreground text-xs underline"
-                      disabled={processing === companion.id}
-                      onClick={() =>
-                        handleUndo(
-                          viewState.invitation.id,
-                          "companion",
-                          companion.id,
-                        )
-                      }
-                    >
-                      取り消し
-                    </button>
-                  </div>
-                ) : (
-                  <Button
-                    size="sm"
-                    disabled={processing === companion.id}
-                    onClick={() =>
-                      handleCheckIn(
-                        viewState.invitation.id,
-                        "companion",
-                        companion.id,
-                      )
-                    }
-                  >
-                    チェックイン
-                  </Button>
-                )}
-              </div>
-            ))}
-
-            {/* 次のゲストボタン */}
-            <div className="flex justify-center pt-2">
-              <Button
-                variant="outline"
-                onClick={startScanning}
-                className="gap-2"
-              >
-                <QrCode className="size-4" />
-                次のゲスト
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
-      )}
+        </DialogContent>
+      </Dialog>
     </div>
+  );
+}
+
+type ResultPanelProps = {
+  viewState:
+    | { mode: "loading"; source: ResultSource }
+    | { mode: "error"; message: string; source: ResultSource }
+    | {
+        mode: "found";
+        invitation: LookupInvitation;
+        source: ResultSource;
+      };
+  processing: string | null;
+  onCheckIn: (
+    invitationId: string,
+    targetType: "guest" | "companion",
+    targetId?: string,
+  ) => void;
+  onUndo: (
+    invitationId: string,
+    targetType: "guest" | "companion",
+    targetId?: string,
+  ) => void;
+  onRescan: () => void;
+  /** dialog の中か inline か。dialog ではカードの枠を省略する */
+  variant?: "inline" | "dialog";
+};
+
+function ResultPanel({
+  viewState,
+  processing,
+  onCheckIn,
+  onUndo,
+  onRescan,
+  variant = "inline",
+}: ResultPanelProps) {
+  if (viewState.mode === "loading") {
+    return (
+      <div className="flex flex-col items-center gap-2 py-8">
+        <Spinner className="size-8 animate-spin" />
+        <p className="text-muted-foreground text-sm">照会中...</p>
+      </div>
+    );
+  }
+
+  if (viewState.mode === "error") {
+    const body = (
+      <div className="flex flex-col items-center gap-4 pt-6">
+        <Warning className="text-destructive size-10" />
+        <p className="text-destructive text-center text-sm">
+          {viewState.message}
+        </p>
+        <Button variant="outline" onClick={onRescan}>
+          再スキャン
+        </Button>
+      </div>
+    );
+    if (variant === "dialog") return body;
+    return (
+      <Card>
+        <CardContent>{body}</CardContent>
+      </Card>
+    );
+  }
+
+  const inv = viewState.invitation;
+  const body = (
+    <div className="space-y-3">
+      {/* ゲスト本人 */}
+      <div className="flex min-h-14 items-center justify-between rounded-md border p-3">
+        <div className="flex items-center gap-2">
+          <User className="text-muted-foreground size-4" />
+          <span className="text-sm font-medium">本人</span>
+          {inv.checkedIn && inv.checkedInAt && (
+            <span className="text-muted-foreground text-xs">
+              {formatTimestamp(inv.checkedInAt)}
+            </span>
+          )}
+        </div>
+        {inv.checkedIn ? (
+          <div className="flex items-center gap-2">
+            <CheckCircle className="size-5 text-emerald-800/70" weight="fill" />
+            <button
+              type="button"
+              className="text-muted-foreground text-xs underline"
+              disabled={processing === "guest"}
+              onClick={() => onUndo(inv.id, "guest")}
+            >
+              取り消し
+            </button>
+          </div>
+        ) : (
+          <Button
+            size="sm"
+            disabled={processing === "guest"}
+            onClick={() => onCheckIn(inv.id, "guest")}
+          >
+            チェックイン
+          </Button>
+        )}
+      </div>
+
+      {/* 同伴者 */}
+      {inv.companions.map((companion) => (
+        <div
+          key={companion.id}
+          className="flex min-h-14 items-center justify-between rounded-md border p-3"
+        >
+          <div className="flex items-center gap-2">
+            <Users className="text-muted-foreground size-4" />
+            <span className="text-sm font-medium">{companion.name}</span>
+            {companion.checkedIn && companion.checkedInAt && (
+              <span className="text-muted-foreground text-xs">
+                {formatTimestamp(companion.checkedInAt)}
+              </span>
+            )}
+          </div>
+          {companion.checkedIn ? (
+            <div className="flex items-center gap-2">
+              <CheckCircle
+                className="size-5 text-emerald-800/70"
+                weight="fill"
+              />
+              <button
+                type="button"
+                className="text-muted-foreground text-xs underline"
+                disabled={processing === companion.id}
+                onClick={() => onUndo(inv.id, "companion", companion.id)}
+              >
+                取り消し
+              </button>
+            </div>
+          ) : (
+            <Button
+              size="sm"
+              disabled={processing === companion.id}
+              onClick={() => onCheckIn(inv.id, "companion", companion.id)}
+            >
+              チェックイン
+            </Button>
+          )}
+        </div>
+      ))}
+
+      {/* 次のゲストボタン */}
+      <div className="flex justify-center pt-2">
+        <Button variant="outline" onClick={onRescan} className="gap-2">
+          <QrCode className="size-4" />
+          次のゲスト
+        </Button>
+      </div>
+    </div>
+  );
+
+  if (variant === "dialog") {
+    return (
+      <div>
+        {inv.guestEmail && (
+          <p className="text-muted-foreground text-sm mb-3">{inv.guestEmail}</p>
+        )}
+        {body}
+      </div>
+    );
+  }
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">
+          {inv.guestName ?? "名前未登録"}
+        </CardTitle>
+        {inv.guestEmail && (
+          <p className="text-muted-foreground text-sm">{inv.guestEmail}</p>
+        )}
+      </CardHeader>
+      <CardContent>{body}</CardContent>
+    </Card>
   );
 }

--- a/src/app/_components/check-in-view.tsx
+++ b/src/app/_components/check-in-view.tsx
@@ -74,12 +74,14 @@ function extractToken(scannedValue: string): string | null {
   return match ? match[1] : null;
 }
 
-/** タイムスタンプを HH:mm 形式にフォーマット */
+/** タイムスタンプを JST の HH:mm 形式にフォーマット */
 function formatTimestamp(ts: number): string {
-  const date = new Date(ts);
-  const h = String(date.getHours()).padStart(2, "0");
-  const m = String(date.getMinutes()).padStart(2, "0");
-  return `${h}:${m}`;
+  return new Intl.DateTimeFormat("ja-JP", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: "Asia/Tokyo",
+  }).format(new Date(ts));
 }
 
 export function CheckInView({
@@ -533,25 +535,24 @@ export function CheckInView({
         </Card>
       )}
 
-      {/* サマリーカード */}
+      {/* サマリーカード：チェックイン済み / 出席予定 合計 */}
       <Card>
         <CardHeader>
           <CardTitle className="text-base">来場者数</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="flex gap-8">
-            <div className="flex items-center gap-2">
-              <User className="text-muted-foreground size-5" />
-              <span className="text-sm">
-                ゲスト: {summary.checkedInGuests}/{summary.totalAccepted}
-              </span>
-            </div>
-            <div className="flex items-center gap-2">
-              <Users className="text-muted-foreground size-5" />
-              <span className="text-sm">
-                同伴者: {summary.checkedInCompanions}/{summary.totalCompanions}
-              </span>
-            </div>
+          <div className="flex items-baseline gap-2">
+            <Users className="text-muted-foreground size-5 self-center" />
+            <span className="text-2xl font-light tabular-nums">
+              {summary.checkedInGuests + summary.checkedInCompanions}
+            </span>
+            <span className="text-muted-foreground text-sm">/</span>
+            <span className="text-muted-foreground tabular-nums">
+              {summary.totalAccepted + summary.totalCompanions}
+            </span>
+            <span className="text-muted-foreground text-xs ml-1">
+              名がチェックイン済み
+            </span>
           </div>
         </CardContent>
       </Card>
@@ -659,7 +660,7 @@ export function CheckInView({
           if (!open) setViewState({ mode: "idle" });
         }}
       >
-        <DialogContent className="max-w-md">
+        <DialogContent className="max-w-md max-h-[calc(100dvh-2rem)] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>
               {viewState.mode === "found"

--- a/src/app/_components/check-in-view.tsx
+++ b/src/app/_components/check-in-view.tsx
@@ -16,6 +16,7 @@ import {
   type LookupInvitation,
   lookupInvitationByToken,
   performCheckIn,
+  type SearchInvitationResult,
   searchInvitationByName,
   undoCheckIn,
 } from "@/app/(main)/events/[eventId]/checkin/_actions";
@@ -284,9 +285,9 @@ export function CheckInView({
     setViewState({ mode: "scanning" });
   };
 
-  const [searchResults, setSearchResults] = useState<LookupInvitation[] | null>(
-    null,
-  );
+  const [searchResults, setSearchResults] = useState<
+    SearchInvitationResult[] | null
+  >(null);
 
   const handleSearch = async () => {
     if (!searchQuery.trim()) return;
@@ -385,7 +386,7 @@ export function CheckInView({
           <CardContent className="space-y-4">
             <div className="flex gap-2">
               <Input
-                placeholder="ゲスト名を入力"
+                placeholder="ゲスト名・同伴者名を入力"
                 value={searchQuery}
                 onChange={(e) => {
                   setSearchQuery(e.target.value);
@@ -419,33 +420,55 @@ export function CheckInView({
 
             {searchResults && searchResults.length > 0 && (
               <div className="space-y-1">
-                {searchResults.map((inv) => (
-                  <button
-                    key={inv.id}
-                    type="button"
-                    className="flex w-full items-center gap-2 rounded-md px-3 py-3 hover:bg-muted/50 transition-colors border"
-                    onClick={() =>
-                      setViewState({ mode: "found", invitation: inv })
-                    }
-                  >
-                    {inv.checkedIn ? (
-                      <CheckCircle
-                        className="size-4 shrink-0 text-emerald-800/70"
-                        weight="fill"
-                      />
-                    ) : (
-                      <Circle className="size-4 shrink-0 text-muted-foreground" />
-                    )}
-                    <span className="text-sm flex-1 text-left">
-                      {inv.guestName ?? "名前未登録"}
-                    </span>
-                    {inv.companions.length > 0 && (
-                      <span className="text-muted-foreground text-xs">
-                        +{inv.companions.length}名
-                      </span>
-                    )}
-                  </button>
-                ))}
+                {searchResults.map((inv) => {
+                  const matchedCompanionNames = inv.companions
+                    .filter((c) => inv.matchedCompanionIds.includes(c.id))
+                    .map((c) => c.name);
+                  return (
+                    <button
+                      key={inv.id}
+                      type="button"
+                      className="flex w-full items-start gap-2 rounded-md px-3 py-3 hover:bg-muted/50 transition-colors border"
+                      onClick={() =>
+                        setViewState({
+                          mode: "found",
+                          invitation: {
+                            id: inv.id,
+                            guestName: inv.guestName,
+                            guestEmail: inv.guestEmail,
+                            checkedIn: inv.checkedIn,
+                            checkedInAt: inv.checkedInAt,
+                            companions: inv.companions,
+                          },
+                        })
+                      }
+                    >
+                      {inv.checkedIn ? (
+                        <CheckCircle
+                          className="size-4 shrink-0 mt-0.5 text-emerald-800/70"
+                          weight="fill"
+                        />
+                      ) : (
+                        <Circle className="size-4 shrink-0 mt-0.5 text-muted-foreground" />
+                      )}
+                      <div className="flex-1 text-left">
+                        <div className="text-sm">
+                          {inv.guestName ?? "名前未登録"}
+                          {inv.companions.length > 0 && (
+                            <span className="text-muted-foreground text-xs ml-2">
+                              +{inv.companions.length}名
+                            </span>
+                          )}
+                        </div>
+                        {matchedCompanionNames.length > 0 && (
+                          <div className="text-muted-foreground text-xs mt-0.5">
+                            同伴者: {matchedCompanionNames.join("、")}
+                          </div>
+                        )}
+                      </div>
+                    </button>
+                  );
+                })}
               </div>
             )}
           </CardContent>

--- a/src/app/_components/create-invitation-button.tsx
+++ b/src/app/_components/create-invitation-button.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { buildShareUrl } from "@/lib/share-url";
 
 export function CreateInvitationButton({ eventId }: { eventId: string }) {
   const [isPending, startTransition] = useTransition();
@@ -23,7 +24,7 @@ export function CreateInvitationButton({ eventId }: { eventId: string }) {
         toast.error(result.error);
         return;
       }
-      const url = `${window.location.origin}/i/${result.token}`;
+      const url = buildShareUrl(`/i/${result.token}`);
       try {
         await navigator.clipboard.writeText(url);
         toast.success("招待リンクをコピーしました");

--- a/src/app/_components/event-card-inner.tsx
+++ b/src/app/_components/event-card-inner.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Spinner } from "@phosphor-icons/react";
+import { useLinkStatus } from "next/link";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { EventStatus, MemberRole } from "@/db/schema";
+import { statusLabels, statusVariants } from "@/lib/event-status";
+import { formatDatetime } from "@/lib/format";
+import { cn } from "@/lib/utils";
+
+export function EventCardInner({
+  event,
+}: {
+  event: {
+    id: string;
+    name: string;
+    startDatetime: string;
+    venue: string;
+    status: EventStatus;
+    role: MemberRole;
+  };
+}) {
+  const { pending } = useLinkStatus();
+
+  return (
+    <Card
+      className={cn(
+        "transition-all duration-300 ease-out hover:scale-[1.01] hover:bg-accent/50",
+        pending && "opacity-60",
+      )}
+    >
+      <CardHeader className="flex flex-row items-start justify-between">
+        <div>
+          <CardTitle className="font-light tracking-wide flex items-center gap-2">
+            {pending && <Spinner className="size-4 animate-spin" />}
+            {event.name}
+          </CardTitle>
+          <CardDescription className="leading-relaxed">
+            {formatDatetime(event.startDatetime)} / {event.venue}
+          </CardDescription>
+        </div>
+        <Badge variant={statusVariants[event.status]}>
+          {statusLabels[event.status]}
+        </Badge>
+      </CardHeader>
+    </Card>
+  );
+}

--- a/src/app/_components/event-card.tsx
+++ b/src/app/_components/event-card.tsx
@@ -1,14 +1,6 @@
 import Link from "next/link";
-import { Badge } from "@/components/ui/badge";
-import {
-  Card,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { EventCardInner } from "@/app/_components/event-card-inner";
 import type { EventStatus, MemberRole } from "@/db/schema";
-import { statusLabels, statusVariants } from "@/lib/event-status";
-import { formatDatetime } from "@/lib/format";
 
 type EventCardProps = {
   event: {
@@ -24,21 +16,7 @@ type EventCardProps = {
 export function EventCard({ event }: EventCardProps) {
   return (
     <Link href={`/events/${event.id}`}>
-      <Card className="transition-all duration-300 ease-out hover:scale-[1.01] hover:bg-accent/50">
-        <CardHeader className="flex flex-row items-start justify-between">
-          <div>
-            <CardTitle className="font-light tracking-wide">
-              {event.name}
-            </CardTitle>
-            <CardDescription className="leading-relaxed">
-              {formatDatetime(event.startDatetime)} / {event.venue}
-            </CardDescription>
-          </div>
-          <Badge variant={statusVariants[event.status]}>
-            {statusLabels[event.status]}
-          </Badge>
-        </CardHeader>
-      </Card>
+      <EventCardInner event={event} />
     </Link>
   );
 }

--- a/src/app/_components/event-detail.tsx
+++ b/src/app/_components/event-detail.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useActionState, useState, useTransition } from "react";
 import { toast } from "sonner";
+import { PendingLinkIndicator } from "@/app/_components/pending-link-indicator";
 import {
   deleteEvent,
   updateEvent,
@@ -286,16 +287,24 @@ export function EventDetail({
         </CardHeader>
         <CardContent className="flex flex-col gap-3">
           <Button variant="outline" asChild className="tracking-wider">
-            <Link href={`/events/${event.id}/programs`}>プログラム管理</Link>
+            <Link href={`/events/${event.id}/programs`}>
+              <PendingLinkIndicator>プログラム管理</PendingLinkIndicator>
+            </Link>
           </Button>
           <Button variant="outline" asChild className="tracking-wider">
-            <Link href={`/events/${event.id}/members`}>メンバー管理</Link>
+            <Link href={`/events/${event.id}/members`}>
+              <PendingLinkIndicator>メンバー管理</PendingLinkIndicator>
+            </Link>
           </Button>
           <Button variant="outline" asChild className="tracking-wider">
-            <Link href={`/events/${event.id}/invitations`}>招待管理</Link>
+            <Link href={`/events/${event.id}/invitations`}>
+              <PendingLinkIndicator>招待管理</PendingLinkIndicator>
+            </Link>
           </Button>
           <Button variant="outline" asChild className="tracking-wider">
-            <Link href={`/events/${event.id}/checkin`}>チェックイン</Link>
+            <Link href={`/events/${event.id}/checkin`}>
+              <PendingLinkIndicator>チェックイン</PendingLinkIndicator>
+            </Link>
           </Button>
         </CardContent>
       </Card>

--- a/src/app/_components/invitation-list.tsx
+++ b/src/app/_components/invitation-list.tsx
@@ -29,6 +29,7 @@ import {
 import { Separator } from "@/components/ui/separator";
 import type { EventStatus } from "@/db/schema";
 import type { InvitationItem } from "@/lib/queries/invitations";
+import { buildShareUrl } from "@/lib/share-url";
 
 // ============================================================
 // 定数
@@ -147,7 +148,7 @@ function InvitationRow({
   const canCopyLink = !isInvalidated;
 
   const handleCopyLink = async () => {
-    const url = `${window.location.origin}/i/${invitation.token}`;
+    const url = buildShareUrl(`/i/${invitation.token}`);
     try {
       await navigator.clipboard.writeText(url);
       toast.success("リンクをコピーしました");

--- a/src/app/_components/invite-performer-form.tsx
+++ b/src/app/_components/invite-performer-form.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { buildShareUrl } from "@/lib/share-url";
 
 export function InvitePerformerForm({ eventId }: { eventId: string }) {
   const [isPending, startTransition] = useTransition();
@@ -20,7 +21,7 @@ export function InvitePerformerForm({ eventId }: { eventId: string }) {
         return;
       }
       if (result && "token" in result) {
-        const url = `${window.location.origin}/join/${result.token}`;
+        const url = buildShareUrl(`/join/${result.token}`);
         try {
           await navigator.clipboard.writeText(url);
           toast.success("招待リンクをコピーしました");

--- a/src/app/_components/navigation-sheet.tsx
+++ b/src/app/_components/navigation-sheet.tsx
@@ -3,6 +3,7 @@
 import { House, Plus, SignOut } from "@phosphor-icons/react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
+import { PendingLinkIndicator } from "@/app/_components/pending-link-indicator";
 import {
   Sheet,
   SheetContent,
@@ -55,7 +56,7 @@ export function NavigationSheet({ open, onOpenChange }: NavigationSheetProps) {
                 }`}
               >
                 <Icon weight="light" className="size-4" />
-                {label}
+                <PendingLinkIndicator>{label}</PendingLinkIndicator>
               </Link>
             );
           })}

--- a/src/app/_components/pending-link-indicator.tsx
+++ b/src/app/_components/pending-link-indicator.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { Spinner } from "@phosphor-icons/react";
+import { useLinkStatus } from "next/link";
+
+/**
+ * next/link の子として使うと、遷移中にスピナーを表示する。
+ * useLinkStatus は親 Link の pending 状態を購読する。
+ */
+export function PendingLinkIndicator({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { pending } = useLinkStatus();
+  return (
+    <span className="inline-flex items-center gap-2">
+      {pending && <Spinner className="size-4 animate-spin" />}
+      {children}
+    </span>
+  );
+}

--- a/src/app/_components/performer-invitation-list.tsx
+++ b/src/app/_components/performer-invitation-list.tsx
@@ -12,6 +12,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import type { EventStatus, PerformerInvitationStatus } from "@/db/schema";
 import type { PerformerInvitationItem } from "@/lib/queries/members";
+import { buildShareUrl } from "@/lib/share-url";
 
 const invitationStatusLabels: Record<PerformerInvitationStatus, string> = {
   pending: "未承認",
@@ -47,7 +48,7 @@ export function PerformerInvitationList({
 
   const handleCopy = useCallback(async (token: string) => {
     try {
-      const url = `${window.location.origin}/join/${token}`;
+      const url = buildShareUrl(`/join/${token}`);
       await navigator.clipboard.writeText(url);
       toast.success("リンクをコピーしました");
     } catch {

--- a/src/app/_components/program-form.tsx
+++ b/src/app/_components/program-form.tsx
@@ -255,21 +255,6 @@ export function ProgramForm({
 
       <div className="grid gap-4 sm:grid-cols-2">
         <div className="flex flex-col gap-2">
-          <Label htmlFor="scheduledTime">
-            予定時刻
-            <span className="text-muted-foreground ml-1 text-xs font-normal">
-              （任意）
-            </span>
-          </Label>
-          <Input
-            id="scheduledTime"
-            name="scheduledTime"
-            type="time"
-            defaultValue={initialData?.scheduledTime ?? ""}
-          />
-        </div>
-
-        <div className="flex flex-col gap-2">
           <Label htmlFor="estimatedDuration">
             所要時間（分）
             <span className="text-muted-foreground ml-1 text-xs font-normal">
@@ -283,6 +268,21 @@ export function ProgramForm({
             min={1}
             max={999}
             defaultValue={initialData?.estimatedDuration ?? ""}
+          />
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="scheduledTime">
+            予定時刻
+            <span className="text-muted-foreground ml-1 text-xs font-normal">
+              （任意）
+            </span>
+          </Label>
+          <Input
+            id="scheduledTime"
+            name="scheduledTime"
+            type="time"
+            defaultValue={initialData?.scheduledTime ?? ""}
           />
         </div>
       </div>

--- a/src/app/_components/program-form.tsx
+++ b/src/app/_components/program-form.tsx
@@ -66,6 +66,18 @@ export function ProgramForm({
       composer: p.composer ?? "",
     })) ?? [{ id: crypto.randomUUID(), title: "", composer: "" }],
   );
+  // 任意入力欄は controlled 化する。React 19 の form action では
+  // 送信時に uncontrolled 入力が自動リセットされるため、バリデーション
+  // エラーで再表示した際に値が消えてしまう。
+  const [scheduledTime, setScheduledTime] = useState(
+    initialData?.scheduledTime ?? "",
+  );
+  const [estimatedDuration, setEstimatedDuration] = useState(
+    initialData?.estimatedDuration != null
+      ? String(initialData.estimatedDuration)
+      : "",
+  );
+  const [note, setNote] = useState(initialData?.note ?? "");
   const [isPending, startTransition] = useTransition();
 
   const [state, formAction] = useActionState<ProgramActionState, FormData>(
@@ -73,9 +85,9 @@ export function ProgramForm({
       const data = {
         type: formData.get("type") as string,
         pieces,
-        scheduledTime: formData.get("scheduledTime") as string,
-        estimatedDuration: formData.get("estimatedDuration") as string,
-        note: formData.get("note") as string,
+        scheduledTime,
+        estimatedDuration,
+        note,
         performerIds: selectedPerformerIds,
       };
       const result =
@@ -92,6 +104,9 @@ export function ProgramForm({
           setSelectedType("performance");
           setSelectedPerformerIds([]);
           setPieces([{ id: crypto.randomUUID(), title: "", composer: "" }]);
+          setScheduledTime("");
+          setEstimatedDuration("");
+          setNote("");
         }
         onSuccess?.();
       } else if (result.error && !result.fieldErrors) {
@@ -222,7 +237,7 @@ export function ProgramForm({
               />
               {selectedType === "performance" && (
                 <Input
-                  placeholder="作曲者"
+                  placeholder="作曲者・作詞者・編曲者など"
                   value={piece.composer}
                   onChange={(e) => updatePiece(i, "composer", e.target.value)}
                 />
@@ -267,7 +282,8 @@ export function ProgramForm({
             type="number"
             min={1}
             max={999}
-            defaultValue={initialData?.estimatedDuration ?? ""}
+            value={estimatedDuration}
+            onChange={(e) => setEstimatedDuration(e.target.value)}
           />
         </div>
 
@@ -282,7 +298,8 @@ export function ProgramForm({
             id="scheduledTime"
             name="scheduledTime"
             type="time"
-            defaultValue={initialData?.scheduledTime ?? ""}
+            value={scheduledTime}
+            onChange={(e) => setScheduledTime(e.target.value)}
           />
         </div>
       </div>
@@ -297,7 +314,8 @@ export function ProgramForm({
         <Textarea
           id="note"
           name="note"
-          defaultValue={initialData?.note ?? ""}
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
           maxLength={500}
           rows={2}
         />

--- a/src/app/_components/program-list.tsx
+++ b/src/app/_components/program-list.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { DotsSixVertical, PencilSimple, Trash } from "@phosphor-icons/react";
-import { Reorder } from "motion/react";
+import { Reorder, useDragControls } from "motion/react";
 import { useRef, useState, useTransition } from "react";
 import { toast } from "sonner";
 import {
@@ -99,120 +99,155 @@ export function ProgramList({
             className="flex flex-col gap-2"
           >
             {programs.map((program, index) => (
-              <Reorder.Item
+              <ProgramRow
                 key={program.id}
-                value={program}
-                dragListener={canModify}
-                className={cn(
-                  "flex items-center gap-2 rounded-lg p-3",
-                  program.type === "performance"
-                    ? "border bg-card"
-                    : "border bg-muted/50",
-                )}
-                whileDrag={{
-                  scale: 1.02,
-                  boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
-                }}
-              >
-                {canModify && (
-                  <DotsSixVertical
-                    className="mt-0.5 text-muted-foreground shrink-0 cursor-grab"
-                    size={16}
-                  />
-                )}
-
-                <span className="mt-0.5 text-muted-foreground/60 shrink-0 text-xs tabular-nums">
-                  {index + 1}
-                </span>
-
-                {program.type === "performance" ? (
-                  <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-                    {program.performers.length > 0 && (
-                      <span className="min-w-0 font-medium">
-                        {program.performers
-                          .map((p) => p.displayName)
-                          .join(", ")}
-                      </span>
-                    )}
-                    {program.pieces.map((piece) => (
-                      <div
-                        key={piece.id}
-                        className="flex items-baseline gap-2 text-sm text-muted-foreground"
-                      >
-                        <span>{piece.title}</span>
-                        {piece.composer && (
-                          <span className="text-muted-foreground/60">
-                            {piece.composer}
-                          </span>
-                        )}
-                      </div>
-                    ))}
-                    {program.estimatedDuration && (
-                      <span className="text-xs text-muted-foreground">
-                        {program.estimatedDuration}分
-                      </span>
-                    )}
-                  </div>
-                ) : (
-                  <div className="flex min-w-0 flex-1 items-baseline gap-2 text-sm text-muted-foreground">
-                    <span>{program.pieces[0]?.title}</span>
-                    {program.estimatedDuration && (
-                      <span className="text-xs">
-                        {program.estimatedDuration}分
-                      </span>
-                    )}
-                  </div>
-                )}
-
-                {canModify && (
-                  <div className="flex shrink-0">
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="size-7"
-                      onClick={() => onEdit(program)}
-                    >
-                      <PencilSimple size={14} />
-                    </Button>
-
-                    <AlertDialog>
-                      <AlertDialogTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="size-7 text-muted-foreground hover:text-destructive"
-                        >
-                          <Trash size={14} />
-                        </Button>
-                      </AlertDialogTrigger>
-                      <AlertDialogContent>
-                        <AlertDialogHeader>
-                          <AlertDialogTitle>プログラムを削除</AlertDialogTitle>
-                          <AlertDialogDescription>
-                            「
-                            {program.type === "performance"
-                              ? `${program.performers.map((p) => p.displayName).join(", ")} - ${program.pieces[0]?.title ?? ""}`
-                              : (program.pieces[0]?.title ?? "このプログラム")}
-                            」を削除してもよろしいですか？この操作は取り消せません。
-                          </AlertDialogDescription>
-                        </AlertDialogHeader>
-                        <AlertDialogFooter>
-                          <AlertDialogCancel>キャンセル</AlertDialogCancel>
-                          <AlertDialogAction
-                            onClick={() => handleDelete(program.id)}
-                          >
-                            削除する
-                          </AlertDialogAction>
-                        </AlertDialogFooter>
-                      </AlertDialogContent>
-                    </AlertDialog>
-                  </div>
-                )}
-              </Reorder.Item>
+                program={program}
+                index={index}
+                canModify={canModify}
+                onEdit={onEdit}
+                onDelete={handleDelete}
+              />
             ))}
           </Reorder.Group>
         )}
       </CardContent>
     </Card>
+  );
+}
+
+type ProgramRowProps = {
+  program: ProgramWithPerformers;
+  index: number;
+  canModify: boolean;
+  onEdit: (program: ProgramWithPerformers) => void;
+  onDelete: (programId: string) => void;
+};
+
+function ProgramRow({
+  program,
+  index,
+  canModify,
+  onEdit,
+  onDelete,
+}: ProgramRowProps) {
+  const dragControls = useDragControls();
+  // 削除確認に表示する演目表記（複数曲の場合はすべて列挙）
+  const deleteTargetLabel =
+    program.type === "performance"
+      ? `${program.performers.map((p) => p.displayName).join(", ")} - ${program.pieces.map((piece) => piece.title).join(" / ")}`
+      : (program.pieces[0]?.title ?? "このプログラム");
+
+  return (
+    <Reorder.Item
+      value={program}
+      dragListener={false}
+      dragControls={dragControls}
+      className={cn(
+        "flex items-center gap-2 rounded-lg p-3",
+        program.type === "performance"
+          ? "border bg-card"
+          : "border bg-muted/50",
+      )}
+      whileDrag={{
+        scale: 1.02,
+        boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
+      }}
+    >
+      {canModify && (
+        <button
+          type="button"
+          aria-label="並び替え"
+          className="mt-0.5 shrink-0 cursor-grab touch-none p-1 text-muted-foreground active:cursor-grabbing"
+          onPointerDown={(e) => dragControls.start(e)}
+        >
+          <DotsSixVertical size={16} />
+        </button>
+      )}
+
+      <span className="mt-0.5 text-muted-foreground/60 shrink-0 text-xs tabular-nums">
+        {index + 1}
+      </span>
+
+      {program.type === "performance" ? (
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          {program.performers.length > 0 && (
+            <span className="min-w-0 font-medium">
+              {program.performers.map((p) => p.displayName).join(", ")}
+            </span>
+          )}
+          {program.pieces.map((piece) => (
+            <div
+              key={piece.id}
+              className="flex items-baseline gap-2 text-sm text-muted-foreground"
+            >
+              <span>{piece.title}</span>
+              {piece.composer && (
+                <span className="text-muted-foreground/60">
+                  {piece.composer}
+                </span>
+              )}
+            </div>
+          ))}
+          {(program.estimatedDuration || program.scheduledTime) && (
+            <span className="text-xs text-muted-foreground">
+              {program.estimatedDuration && `${program.estimatedDuration}分`}
+              {program.estimatedDuration && program.scheduledTime && " / "}
+              {program.scheduledTime && `${program.scheduledTime}〜`}
+            </span>
+          )}
+        </div>
+      ) : (
+        <div className="flex min-w-0 flex-1 items-baseline gap-2 text-sm text-muted-foreground">
+          <span>{program.pieces[0]?.title}</span>
+          {(program.estimatedDuration || program.scheduledTime) && (
+            <span className="text-xs">
+              {program.estimatedDuration && `${program.estimatedDuration}分`}
+              {program.estimatedDuration && program.scheduledTime && " / "}
+              {program.scheduledTime && `${program.scheduledTime}〜`}
+            </span>
+          )}
+        </div>
+      )}
+
+      {canModify && (
+        <div className="flex shrink-0">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-7"
+            onClick={() => onEdit(program)}
+          >
+            <PencilSimple size={14} />
+          </Button>
+
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7 text-muted-foreground hover:text-destructive"
+              >
+                <Trash size={14} />
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>プログラムを削除</AlertDialogTitle>
+                <AlertDialogDescription>
+                  「{deleteTargetLabel}
+                  」を削除してもよろしいですか？この操作は取り消せません。
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>キャンセル</AlertDialogCancel>
+                <AlertDialogAction onClick={() => onDelete(program.id)}>
+                  削除する
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
+      )}
+    </Reorder.Item>
   );
 }

--- a/src/app/_components/program-management.tsx
+++ b/src/app/_components/program-management.tsx
@@ -74,7 +74,7 @@ export function ProgramManagement({
           if (!open) setEditingProgram(null);
         }}
       >
-        <DialogContent>
+        <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>プログラムを編集</DialogTitle>
           </DialogHeader>

--- a/src/app/i/[token]/page.tsx
+++ b/src/app/i/[token]/page.tsx
@@ -113,10 +113,13 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
 }
 
 function formatCheckInTime(ts: number): string {
-  const date = new Date(ts);
-  const h = String(date.getHours()).padStart(2, "0");
-  const m = String(date.getMinutes()).padStart(2, "0");
-  return `${h}:${m}`;
+  // SSR 環境（UTC）でも JST で表示するため timeZone を明示する
+  return new Intl.DateTimeFormat("ja-JP", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: "Asia/Tokyo",
+  }).format(new Date(ts));
 }
 
 // ============================================================

--- a/src/lib/share-url.ts
+++ b/src/lib/share-url.ts
@@ -1,0 +1,12 @@
+/**
+ * LINE 等の SNS でリンクをシェアした際、受け手が LINE 内蔵ブラウザで
+ * 開くのを避けるためのクエリパラメータ付き URL を返す。
+ *
+ * LINE は URL に `?openExternalBrowser=1` が付いていると、タップ時に
+ * 端末標準ブラウザで開く仕様。（他 SNS では無害なため常時付与）
+ */
+export function buildShareUrl(path: string): string {
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  const separator = path.includes("?") ? "&" : "?";
+  return `${origin}${path}${separator}openExternalBrowser=1`;
+}


### PR DESCRIPTION
同伴者名で検索した際、結果リストにゲスト（親）名しか表示されず、
どの同伴者がヒットしたか分からない問題を修正。

- searchInvitationByName の戻り値に guestNameMatched と
  matchedCompanionIds を追加
- 検索結果カードにマッチした同伴者名を表示
- プレースホルダーを「ゲスト名・同伴者名を入力」に更新

Ref #49