### PR TITLE
feat(programs): 管理画面 UX を操作性・認知負荷・フィードバック軸で刷新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ storybook-static/
 # plan
 .plan/
 
+# playwright-cli artifacts
+.playwright-cli/
+
 # claude code
 .claude/
 

--- a/src/app/_components/program-form.tsx
+++ b/src/app/_components/program-form.tsx
@@ -497,7 +497,7 @@ function findErrorElement(
     return form.querySelector<HTMLElement>("[data-performers-root]");
   }
   if (key === "type") {
-    return form.querySelector<HTMLElement>("[data-type-root]");
+    return form.querySelector<HTMLElement>("[data-type-root] [role='radio']");
   }
   return form.querySelector<HTMLElement>(`[name="${key}"]`);
 }

--- a/src/app/_components/program-form.tsx
+++ b/src/app/_components/program-form.tsx
@@ -1,21 +1,22 @@
 "use client";
 
 import { ArrowDown, ArrowUp, Trash } from "@phosphor-icons/react";
-import { useActionState, useState, useTransition } from "react";
+import {
+  useActionState,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+} from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import {
   PROGRAM_TYPE_LABELS,
   PROGRAM_TYPES,
@@ -44,6 +45,17 @@ type ProgramFormProps = {
   onSuccess?: () => void;
 };
 
+const FIELD_ORDER = [
+  "type",
+  "pieces",
+  "performerIds",
+  "estimatedDuration",
+  "scheduledTime",
+  "note",
+] as const;
+
+type FieldKey = (typeof FIELD_ORDER)[number];
+
 export function ProgramForm({
   eventId,
   members,
@@ -51,6 +63,13 @@ export function ProgramForm({
   initialData,
   onSuccess,
 }: ProgramFormProps) {
+  const formRef = useRef<HTMLFormElement>(null);
+  const durationId = useId();
+  const timeId = useId();
+  const noteId = useId();
+  const piecesErrorId = useId();
+  const performersErrorId = useId();
+
   const [selectedType, setSelectedType] = useState<ProgramType>(
     initialData?.type ?? "performance",
   );
@@ -78,17 +97,30 @@ export function ProgramForm({
       : "",
   );
   const [note, setNote] = useState(initialData?.note ?? "");
+
+  const initialHasDetail = useMemo(
+    () =>
+      Boolean(
+        initialData?.scheduledTime ||
+          initialData?.estimatedDuration != null ||
+          initialData?.note,
+      ) || initialData?.type === "intermission",
+    [initialData],
+  );
+  const [detailOpen, setDetailOpen] = useState(initialHasDetail);
+
   const [isPending, startTransition] = useTransition();
 
   const [state, formAction] = useActionState<ProgramActionState, FormData>(
-    async (_prevState, formData) => {
+    async (_prevState, _formData) => {
       const data = {
-        type: formData.get("type") as string,
+        type: selectedType,
         pieces,
         scheduledTime,
         estimatedDuration,
         note,
-        performerIds: selectedPerformerIds,
+        performerIds:
+          selectedType === "performance" ? selectedPerformerIds : [],
       };
       const result =
         mode === "add"
@@ -107,6 +139,7 @@ export function ProgramForm({
           setScheduledTime("");
           setEstimatedDuration("");
           setNote("");
+          setDetailOpen(false);
         }
         onSuccess?.();
       } else if (result.error && !result.fieldErrors) {
@@ -116,6 +149,52 @@ export function ProgramForm({
     },
     null,
   );
+
+  useEffect(() => {
+    if (!state?.fieldErrors) return;
+    const errorKey = FIELD_ORDER.find((k) => state.fieldErrors?.[k]);
+    if (!errorKey) return;
+
+    if (
+      errorKey === "scheduledTime" ||
+      errorKey === "estimatedDuration" ||
+      errorKey === "note"
+    ) {
+      setDetailOpen(true);
+    }
+
+    const raf = requestAnimationFrame(() => {
+      const form = formRef.current;
+      if (!form) return;
+      const el = findErrorElement(form, errorKey);
+      if (!el) return;
+      el.scrollIntoView({ block: "center", behavior: "smooth" });
+      if (typeof el.focus === "function") {
+        el.focus({ preventScroll: true });
+      }
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [state?.fieldErrors]);
+
+  const handleTypeChange = (next: string) => {
+    if (!next) return;
+    const newType = next as ProgramType;
+    if (newType === selectedType) return;
+    if (
+      selectedType === "performance" &&
+      newType !== "performance" &&
+      pieces.length >= 2
+    ) {
+      const ok = window.confirm(
+        "種別を変更すると、2 件目以降の曲目は削除されます。よろしいですか？",
+      );
+      if (!ok) return;
+    }
+    setSelectedType(newType);
+    if (newType !== "performance") {
+      setPieces((prev) => [prev[0]]);
+    }
+  };
 
   const handlePerformerToggle = (memberId: string, checked: boolean) => {
     setSelectedPerformerIds((prev) =>
@@ -153,240 +232,272 @@ export function ProgramForm({
     });
   };
 
-  const formContent = (
+  const piecesError = state?.fieldErrors?.pieces;
+  const performersError = state?.fieldErrors?.performerIds;
+
+  return (
     <form
+      ref={formRef}
       action={(formData) => {
         startTransition(() => {
           formAction(formData);
         });
       }}
-      className="flex flex-col gap-4"
+      className="flex flex-col gap-5"
     >
-      <div className="grid gap-4 sm:grid-cols-2">
+      <fieldset disabled={isPending} className="contents">
         <div className="flex flex-col gap-2">
-          <Label htmlFor="type">
-            種別<span className="text-destructive ml-1">*</span>
-          </Label>
-          <Select
-            name="type"
+          <Label>種別</Label>
+          <ToggleGroup
+            type="single"
+            variant="outline"
             value={selectedType}
-            onValueChange={(v) => {
-              const newType = v as ProgramType;
-              setSelectedType(newType);
-              if (newType !== "performance") {
-                setPieces((prev) => [prev[0]]);
-              }
-            }}
+            onValueChange={handleTypeChange}
+            data-type-root
+            className="w-fit"
           >
-            <SelectTrigger id="type">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {PROGRAM_TYPES.map((t) => (
-                <SelectItem key={t} value={t}>
-                  {PROGRAM_TYPE_LABELS[t]}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+            {PROGRAM_TYPES.map((t) => (
+              <ToggleGroupItem
+                key={t}
+                value={t}
+                aria-label={PROGRAM_TYPE_LABELS[t]}
+              >
+                {PROGRAM_TYPE_LABELS[t]}
+              </ToggleGroupItem>
+            ))}
+          </ToggleGroup>
           {state?.fieldErrors?.type && (
             <p className="text-sm text-destructive">{state.fieldErrors.type}</p>
           )}
         </div>
-      </div>
 
-      <div className="flex flex-col gap-3">
-        <Label>
-          {selectedType === "performance" ? "曲目" : "タイトル"}
-          <span className="text-destructive ml-1">*</span>
-        </Label>
-        {pieces.map((piece, i) => (
-          <div key={piece.id} className="flex items-start gap-2">
-            {pieces.length > 1 && (
-              <div className="flex flex-col">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="size-6"
-                  disabled={i === 0}
-                  onClick={() => movePiece(i, -1)}
-                >
-                  <ArrowUp size={12} />
-                </Button>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="size-6"
-                  disabled={i === pieces.length - 1}
-                  onClick={() => movePiece(i, 1)}
-                >
-                  <ArrowDown size={12} />
-                </Button>
-              </div>
-            )}
-            <div className="flex flex-1 flex-col gap-1">
-              <Input
-                placeholder={
-                  selectedType === "performance" ? "曲名" : "タイトル"
-                }
-                value={piece.title}
-                onChange={(e) => updatePiece(i, "title", e.target.value)}
-                required
-              />
-              {selectedType === "performance" && (
+        <div className="flex flex-col gap-3">
+          <Label>{selectedType === "performance" ? "曲目" : "タイトル"}</Label>
+          {pieces.map((piece, i) => (
+            <div key={piece.id} className="flex items-start gap-2">
+              {pieces.length > 1 && (
+                <div className="flex flex-col">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="size-6"
+                    disabled={i === 0}
+                    onClick={() => movePiece(i, -1)}
+                    aria-label="上に移動"
+                  >
+                    <ArrowUp size={12} />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="size-6"
+                    disabled={i === pieces.length - 1}
+                    onClick={() => movePiece(i, 1)}
+                    aria-label="下に移動"
+                  >
+                    <ArrowDown size={12} />
+                  </Button>
+                </div>
+              )}
+              <div className="flex flex-1 flex-col gap-1">
                 <Input
-                  placeholder="作曲者・作詞者・編曲者など"
-                  value={piece.composer}
-                  onChange={(e) => updatePiece(i, "composer", e.target.value)}
+                  data-piece-title
+                  placeholder={
+                    selectedType === "performance" ? "曲名" : "タイトル"
+                  }
+                  value={piece.title}
+                  onChange={(e) => updatePiece(i, "title", e.target.value)}
+                  required
+                  aria-invalid={i === 0 && piecesError ? true : undefined}
+                  aria-describedby={
+                    i === 0 && piecesError ? piecesErrorId : undefined
+                  }
                 />
+                {selectedType === "performance" && (
+                  <Input
+                    placeholder="作曲者・作詞者・編曲者など"
+                    value={piece.composer}
+                    onChange={(e) => updatePiece(i, "composer", e.target.value)}
+                  />
+                )}
+              </div>
+              {pieces.length > 1 && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => removePiece(i)}
+                  aria-label="この曲を削除"
+                >
+                  <Trash size={14} />
+                </Button>
               )}
             </div>
-            {pieces.length > 1 && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                onClick={() => removePiece(i)}
-              >
-                <Trash size={14} />
-              </Button>
-            )}
-          </div>
-        ))}
-        {selectedType === "performance" && (
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={addPiece}
-            className="w-fit"
-          >
-            + 曲を追加
-          </Button>
-        )}
-      </div>
-
-      <div className="grid gap-4 sm:grid-cols-2">
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="estimatedDuration">
-            所要時間（分）
-            <span className="text-muted-foreground ml-1 text-xs font-normal">
-              （任意）
-            </span>
-          </Label>
-          <Input
-            id="estimatedDuration"
-            name="estimatedDuration"
-            type="number"
-            min={1}
-            max={999}
-            value={estimatedDuration}
-            onChange={(e) => setEstimatedDuration(e.target.value)}
-          />
-        </div>
-
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="scheduledTime">
-            予定時刻
-            <span className="text-muted-foreground ml-1 text-xs font-normal">
-              （任意）
-            </span>
-          </Label>
-          <Input
-            id="scheduledTime"
-            name="scheduledTime"
-            type="time"
-            value={scheduledTime}
-            onChange={(e) => setScheduledTime(e.target.value)}
-          />
-        </div>
-      </div>
-
-      <div className="flex flex-col gap-2">
-        <Label htmlFor="note">
-          備考
-          <span className="text-muted-foreground ml-1 text-xs font-normal">
-            （任意）
-          </span>
-        </Label>
-        <Textarea
-          id="note"
-          name="note"
-          value={note}
-          onChange={(e) => setNote(e.target.value)}
-          maxLength={500}
-          rows={2}
-        />
-      </div>
-
-      <div className="flex flex-col gap-2">
-        <Label>
-          出演者
-          {selectedType === "performance" ? (
-            <span className="text-destructive ml-1">*</span>
-          ) : (
-            <span className="text-muted-foreground ml-1 text-xs font-normal">
-              （任意）
-            </span>
-          )}
-        </Label>
-        <div className="flex flex-wrap gap-3">
-          {members.map((m) => (
-            <div key={m.id} className="flex items-center gap-2 text-sm">
-              <Checkbox
-                id={`performer-${m.id}`}
-                checked={selectedPerformerIds.includes(m.id)}
-                onCheckedChange={(checked) =>
-                  handlePerformerToggle(m.id, checked === true)
-                }
-              />
-              <Label
-                htmlFor={`performer-${m.id}`}
-                className="text-sm font-normal"
-              >
-                {m.displayName}
-              </Label>
-            </div>
           ))}
-          {members.length === 0 && (
-            <p className="text-sm text-muted-foreground">
-              メンバーが登録されていません
+          {piecesError && (
+            <p id={piecesErrorId} className="text-sm text-destructive">
+              {piecesError}
             </p>
           )}
+          {selectedType === "performance" && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={addPiece}
+              className="w-fit"
+            >
+              + 曲を追加
+            </Button>
+          )}
         </div>
-        {state?.fieldErrors?.performerIds && (
-          <p className="text-sm text-destructive">
-            {state.fieldErrors.performerIds}
-          </p>
-        )}
-      </div>
 
-      <div className="flex justify-end">
-        <Button type="submit" disabled={isPending}>
-          {isPending
-            ? mode === "add"
-              ? "追加中..."
-              : "更新中..."
-            : mode === "add"
-              ? "プログラムを追加"
-              : "プログラムを更新"}
-        </Button>
-      </div>
+        {selectedType === "performance" && (
+          <div className="flex flex-col gap-2">
+            <Label>出演者</Label>
+            <div
+              data-performers-root
+              tabIndex={-1}
+              className="flex flex-wrap gap-3 rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              aria-describedby={performersError ? performersErrorId : undefined}
+            >
+              {members.map((m) => (
+                <div key={m.id} className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    id={`performer-${m.id}`}
+                    checked={selectedPerformerIds.includes(m.id)}
+                    onCheckedChange={(checked) =>
+                      handlePerformerToggle(m.id, checked === true)
+                    }
+                  />
+                  <Label
+                    htmlFor={`performer-${m.id}`}
+                    className="text-sm font-normal"
+                  >
+                    {m.displayName}
+                  </Label>
+                </div>
+              ))}
+              {members.length === 0 && (
+                <p className="text-sm text-muted-foreground">
+                  メンバーが登録されていません
+                </p>
+              )}
+            </div>
+            {performersError && (
+              <p id={performersErrorId} className="text-sm text-destructive">
+                {performersError}
+              </p>
+            )}
+          </div>
+        )}
+
+        {!detailOpen ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => setDetailOpen(true)}
+            className="w-fit text-muted-foreground"
+          >
+            ＋ 詳細（時刻・所要時間・備考）を追加
+          </Button>
+        ) : (
+          <div className="flex flex-col gap-4 rounded-md border border-border/60 bg-muted/20 p-4">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="flex flex-col gap-2">
+                <Label htmlFor={durationId}>
+                  所要時間（分）
+                  <span className="text-muted-foreground ml-1 text-xs font-normal">
+                    任意
+                  </span>
+                </Label>
+                <Input
+                  id={durationId}
+                  name="estimatedDuration"
+                  type="number"
+                  min={1}
+                  max={999}
+                  value={estimatedDuration}
+                  onChange={(e) => setEstimatedDuration(e.target.value)}
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <Label htmlFor={timeId}>
+                  予定時刻
+                  <span className="text-muted-foreground ml-1 text-xs font-normal">
+                    任意
+                  </span>
+                </Label>
+                <Input
+                  id={timeId}
+                  name="scheduledTime"
+                  type="time"
+                  value={scheduledTime}
+                  onChange={(e) => setScheduledTime(e.target.value)}
+                />
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Label htmlFor={noteId}>
+                備考
+                <span className="text-muted-foreground ml-1 text-xs font-normal">
+                  任意
+                </span>
+              </Label>
+              <Textarea
+                id={noteId}
+                name="note"
+                value={note}
+                onChange={(e) => setNote(e.target.value)}
+                maxLength={500}
+                rows={2}
+              />
+            </div>
+
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setDetailOpen(false)}
+              className="w-fit text-muted-foreground"
+            >
+              詳細を閉じる
+            </Button>
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button type="submit" disabled={isPending} className="tracking-wider">
+            {isPending
+              ? mode === "add"
+                ? "追加中..."
+                : "更新中..."
+              : mode === "add"
+                ? "プログラムを追加"
+                : "プログラムを更新"}
+          </Button>
+        </div>
+      </fieldset>
     </form>
   );
+}
 
-  if (mode === "edit") {
-    return formContent;
+function findErrorElement(
+  form: HTMLFormElement,
+  key: FieldKey,
+): HTMLElement | null {
+  if (key === "pieces") {
+    return form.querySelector<HTMLInputElement>("input[data-piece-title]");
   }
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="text-xl font-light">プログラムを追加</CardTitle>
-      </CardHeader>
-      <CardContent>{formContent}</CardContent>
-    </Card>
-  );
+  if (key === "performerIds") {
+    return form.querySelector<HTMLElement>("[data-performers-root]");
+  }
+  if (key === "type") {
+    return form.querySelector<HTMLElement>("[data-type-root]");
+  }
+  return form.querySelector<HTMLElement>(`[name="${key}"]`);
 }

--- a/src/app/_components/program-list.stories.tsx
+++ b/src/app/_components/program-list.stories.tsx
@@ -9,6 +9,7 @@ const meta = {
     onReorder: fn(async () => null),
     onDelete: fn(async () => null),
     onEdit: fn(),
+    onAdd: fn(),
   },
 } satisfies Meta<typeof ProgramList>;
 

--- a/src/app/_components/program-list.tsx
+++ b/src/app/_components/program-list.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { DotsSixVertical, PencilSimple, Trash } from "@phosphor-icons/react";
+import {
+  DotsSixVertical,
+  PencilSimple,
+  Plus,
+  Trash,
+} from "@phosphor-icons/react";
 import { Reorder, useDragControls } from "motion/react";
 import { useRef, useState, useTransition } from "react";
 import { toast } from "sonner";
@@ -16,7 +21,7 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { PROGRAM_TYPE_LABELS } from "@/db/schema";
 import type { ProgramWithPerformers } from "@/lib/queries/programs";
 import { cn } from "@/lib/utils";
 
@@ -33,6 +38,7 @@ type ProgramListProps = {
     programId: string,
   ) => Promise<{ error: string } | null>;
   onEdit: (program: ProgramWithPerformers) => void;
+  onAdd?: () => void;
 };
 
 export function ProgramList({
@@ -42,13 +48,13 @@ export function ProgramList({
   onReorder,
   onDelete,
   onEdit,
+  onAdd,
 }: ProgramListProps) {
   const [programs, setPrograms] =
     useState<ProgramWithPerformers[]>(initialPrograms);
   const [, startTransition] = useTransition();
   const previousOrderRef = useRef<ProgramWithPerformers[]>(initialPrograms);
 
-  // props 更新時にローカル state を同期
   if (initialPrograms !== previousOrderRef.current) {
     previousOrderRef.current = initialPrograms;
     setPrograms(initialPrograms);
@@ -66,6 +72,11 @@ export function ProgramList({
       if (result?.error) {
         setPrograms(prevOrder);
         toast.error(result.error);
+      } else {
+        toast.success("並び順を保存しました", {
+          duration: 1500,
+          id: "program-reorder",
+        });
       }
     });
   };
@@ -81,37 +92,38 @@ export function ProgramList({
     });
   };
 
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="text-xl font-light">プログラム一覧</CardTitle>
-      </CardHeader>
-      <CardContent>
-        {programs.length === 0 ? (
-          <p className="text-muted-foreground text-center py-8">
-            プログラムがありません
-          </p>
-        ) : (
-          <Reorder.Group
-            axis="y"
-            values={programs}
-            onReorder={handleReorder}
-            className="flex flex-col gap-2"
-          >
-            {programs.map((program, index) => (
-              <ProgramRow
-                key={program.id}
-                program={program}
-                index={index}
-                canModify={canModify}
-                onEdit={onEdit}
-                onDelete={handleDelete}
-              />
-            ))}
-          </Reorder.Group>
+  if (programs.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-4 rounded-md border border-dashed border-border/60 bg-card/40 px-6 py-12 text-center">
+        <p className="text-muted-foreground">まだプログラムがありません</p>
+        {canModify && onAdd && (
+          <Button variant="outline" onClick={onAdd} className="tracking-wider">
+            <Plus size={16} />
+            最初のプログラムを追加
+          </Button>
         )}
-      </CardContent>
-    </Card>
+      </div>
+    );
+  }
+
+  return (
+    <Reorder.Group
+      axis="y"
+      values={programs}
+      onReorder={handleReorder}
+      className="flex flex-col divide-y divide-border/60 rounded-md border border-border/60 bg-card/40"
+    >
+      {programs.map((program, index) => (
+        <ProgramRow
+          key={program.id}
+          program={program}
+          index={index}
+          canModify={canModify}
+          onEdit={onEdit}
+          onDelete={handleDelete}
+        />
+      ))}
+    </Reorder.Group>
   );
 }
 
@@ -131,11 +143,20 @@ function ProgramRow({
   onDelete,
 }: ProgramRowProps) {
   const dragControls = useDragControls();
-  // 削除確認に表示する演目表記（複数曲の場合はすべて列挙）
   const deleteTargetLabel =
     program.type === "performance"
       ? `${program.performers.map((p) => p.displayName).join(", ")} - ${program.pieces.map((piece) => piece.title).join(" / ")}`
       : (program.pieces[0]?.title ?? "このプログラム");
+
+  const timeLabel =
+    program.scheduledTime || program.estimatedDuration != null
+      ? [
+          program.scheduledTime && `${program.scheduledTime}〜`,
+          program.estimatedDuration != null && `${program.estimatedDuration}分`,
+        ]
+          .filter(Boolean)
+          .join(" · ")
+      : null;
 
   return (
     <Reorder.Item
@@ -143,78 +164,78 @@ function ProgramRow({
       dragListener={false}
       dragControls={dragControls}
       className={cn(
-        "flex items-center gap-2 rounded-lg p-3",
-        program.type === "performance"
-          ? "border bg-card"
-          : "border bg-muted/50",
+        "group flex items-start gap-3 px-3 py-3 transition-colors first:rounded-t-md last:rounded-b-md",
+        "hover:bg-muted/40 focus-within:bg-muted/40",
+        program.type !== "performance" && "bg-muted/30",
       )}
       whileDrag={{
-        scale: 1.02,
-        boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
+        scale: 1.01,
+        boxShadow: "0 4px 12px rgba(0,0,0,0.08)",
       }}
     >
       {canModify && (
         <button
           type="button"
           aria-label="並び替え"
-          className="mt-0.5 shrink-0 cursor-grab touch-none p-1 text-muted-foreground active:cursor-grabbing"
+          className="mt-0.5 shrink-0 cursor-grab touch-none rounded p-1 text-muted-foreground/60 transition-colors hover:text-muted-foreground active:cursor-grabbing"
           onPointerDown={(e) => dragControls.start(e)}
         >
           <DotsSixVertical size={16} />
         </button>
       )}
 
-      <span className="mt-0.5 text-muted-foreground/60 shrink-0 text-xs tabular-nums">
-        {index + 1}
-      </span>
-
       {program.type === "performance" ? (
-        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-          {program.performers.length > 0 && (
-            <span className="min-w-0 font-medium">
-              {program.performers.map((p) => p.displayName).join(", ")}
-            </span>
-          )}
-          {program.pieces.map((piece) => (
-            <div
-              key={piece.id}
-              className="flex items-baseline gap-2 text-sm text-muted-foreground"
-            >
-              <span>{piece.title}</span>
-              {piece.composer && (
-                <span className="text-muted-foreground/60">
-                  {piece.composer}
-                </span>
-              )}
-            </div>
-          ))}
-          {(program.estimatedDuration || program.scheduledTime) && (
-            <span className="text-xs text-muted-foreground">
-              {program.estimatedDuration && `${program.estimatedDuration}分`}
-              {program.estimatedDuration && program.scheduledTime && " / "}
-              {program.scheduledTime && `${program.scheduledTime}〜`}
-            </span>
-          )}
-        </div>
+        <span className="mt-0.5 w-6 shrink-0 text-sm font-medium tabular-nums text-muted-foreground">
+          {index + 1}.
+        </span>
       ) : (
-        <div className="flex min-w-0 flex-1 items-baseline gap-2 text-sm text-muted-foreground">
-          <span>{program.pieces[0]?.title}</span>
-          {(program.estimatedDuration || program.scheduledTime) && (
-            <span className="text-xs">
-              {program.estimatedDuration && `${program.estimatedDuration}分`}
-              {program.estimatedDuration && program.scheduledTime && " / "}
-              {program.scheduledTime && `${program.scheduledTime}〜`}
-            </span>
-          )}
-        </div>
+        <span className="mt-1 shrink-0 text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
+          {PROGRAM_TYPE_LABELS[program.type]}
+        </span>
+      )}
+
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        {program.type === "performance" ? (
+          <>
+            {program.performers.length > 0 && (
+              <span className="min-w-0 font-medium">
+                {program.performers.map((p) => p.displayName).join(", ")}
+              </span>
+            )}
+            {program.pieces.map((piece) => (
+              <div
+                key={piece.id}
+                className="flex items-baseline gap-2 text-sm text-muted-foreground"
+              >
+                <span>{piece.title}</span>
+                {piece.composer && (
+                  <span className="text-muted-foreground/60">
+                    {piece.composer}
+                  </span>
+                )}
+              </div>
+            ))}
+          </>
+        ) : (
+          <span className="text-sm text-muted-foreground">
+            {program.pieces[0]?.title}
+          </span>
+        )}
+      </div>
+
+      {timeLabel && (
+        <span className="mt-0.5 shrink-0 text-xs tabular-nums text-muted-foreground">
+          {timeLabel}
+        </span>
       )}
 
       {canModify && (
-        <div className="flex shrink-0">
+        <div className="flex shrink-0 items-start gap-0.5 opacity-60 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
           <Button
             variant="ghost"
             size="icon"
             className="size-7"
+            aria-label="編集"
             onClick={() => onEdit(program)}
           >
             <PencilSimple size={14} />
@@ -225,6 +246,7 @@ function ProgramRow({
               <Button
                 variant="ghost"
                 size="icon"
+                aria-label="削除"
                 className="size-7 text-muted-foreground hover:text-destructive"
               >
                 <Trash size={14} />

--- a/src/app/_components/program-management.tsx
+++ b/src/app/_components/program-management.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { Plus } from "@phosphor-icons/react";
 import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -32,29 +34,47 @@ type ProgramManagementProps = {
   currentUserRole: MemberRole;
 };
 
+type DialogState =
+  | { mode: "add" }
+  | { mode: "edit"; program: ProgramWithPerformers }
+  | null;
+
 export function ProgramManagement({
   event,
   programs,
   members,
   currentUserRole,
 }: ProgramManagementProps) {
-  const [editingProgram, setEditingProgram] =
-    useState<ProgramWithPerformers | null>(null);
+  const [dialog, setDialog] = useState<DialogState>(null);
 
   const canModify =
     event.status !== "finished" &&
     (currentUserRole === "organizer" || currentUserRole === "performer");
 
+  const openAdd = () => setDialog({ mode: "add" });
+  const close = () => setDialog(null);
+
   return (
     <div className="flex flex-col gap-8">
-      <div>
-        <h1 className="text-3xl font-light tracking-wide">プログラム管理</h1>
-        <div className="mt-2 flex items-center gap-3">
-          <span className="text-muted-foreground">{event.name}</span>
-          <Badge variant={statusVariants[event.status]}>
-            {statusLabels[event.status]}
-          </Badge>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-3xl font-light tracking-wide">プログラム管理</h1>
+          <div className="mt-2 flex items-center gap-3">
+            <span className="text-muted-foreground">{event.name}</span>
+            <Badge variant={statusVariants[event.status]}>
+              {statusLabels[event.status]}
+            </Badge>
+          </div>
         </div>
+        {canModify && (
+          <Button
+            onClick={openAdd}
+            className="tracking-wider self-start sm:self-auto"
+          >
+            <Plus size={16} />
+            プログラムを追加
+          </Button>
+        )}
       </div>
 
       <ProgramList
@@ -63,39 +83,49 @@ export function ProgramManagement({
         canModify={canModify}
         onReorder={reorderPrograms}
         onDelete={deleteProgram}
-        onEdit={setEditingProgram}
+        onEdit={(program) => setDialog({ mode: "edit", program })}
+        onAdd={canModify ? openAdd : undefined}
       />
 
-      {canModify && <ProgramForm eventId={event.id} members={members} />}
-
       <Dialog
-        open={editingProgram !== null}
+        open={dialog !== null}
         onOpenChange={(open) => {
-          if (!open) setEditingProgram(null);
+          if (!open) close();
         }}
       >
         <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto">
           <DialogHeader>
-            <DialogTitle>プログラムを編集</DialogTitle>
+            <DialogTitle>
+              {dialog?.mode === "edit"
+                ? "プログラムを編集"
+                : "プログラムを追加"}
+            </DialogTitle>
           </DialogHeader>
-          {editingProgram && (
+          {dialog?.mode === "add" && (
+            <ProgramForm
+              eventId={event.id}
+              members={members}
+              onSuccess={close}
+            />
+          )}
+          {dialog?.mode === "edit" && (
             <ProgramForm
               eventId={event.id}
               members={members}
               mode="edit"
               initialData={{
-                id: editingProgram.id,
-                type: editingProgram.type,
-                pieces: editingProgram.pieces.map((p) => ({
+                id: dialog.program.id,
+                type: dialog.program.type,
+                pieces: dialog.program.pieces.map((p) => ({
                   title: p.title,
                   composer: p.composer,
                 })),
-                scheduledTime: editingProgram.scheduledTime,
-                estimatedDuration: editingProgram.estimatedDuration,
-                note: editingProgram.note,
-                performerIds: editingProgram.performers.map((p) => p.memberId),
+                scheduledTime: dialog.program.scheduledTime,
+                estimatedDuration: dialog.program.estimatedDuration,
+                note: dialog.program.note,
+                performerIds: dialog.program.performers.map((p) => p.memberId),
               }}
-              onSuccess={() => setEditingProgram(null)}
+              onSuccess={close}
             />
           )}
         </DialogContent>

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import type { VariantProps } from "class-variance-authority";
+import { ToggleGroup as ToggleGroupPrimitive } from "radix-ui";
+import * as React from "react";
+import { toggleVariants } from "@/components/ui/toggle";
+import { cn } from "@/lib/utils";
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number;
+  }
+>({
+  size: "default",
+  variant: "default",
+  spacing: 0,
+});
+
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  spacing = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number;
+  }) {
+  return (
+    <ToggleGroupPrimitive.Root
+      data-slot="toggle-group"
+      data-variant={variant}
+      data-size={size}
+      data-spacing={spacing}
+      style={{ "--gap": spacing } as React.CSSProperties}
+      className={cn(
+        "group/toggle-group flex w-fit items-center gap-[--spacing(var(--gap))] rounded-md data-[spacing=default]:data-[variant=outline]:shadow-xs",
+        className,
+      )}
+      {...props}
+    >
+      <ToggleGroupContext.Provider value={{ variant, size, spacing }}>
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive.Root>
+  );
+}
+
+function ToggleGroupItem({
+  className,
+  children,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Item> &
+  VariantProps<typeof toggleVariants>) {
+  const context = React.useContext(ToggleGroupContext);
+
+  return (
+    <ToggleGroupPrimitive.Item
+      data-slot="toggle-group-item"
+      data-variant={context.variant || variant}
+      data-size={context.size || size}
+      data-spacing={context.spacing}
+      className={cn(
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        "w-auto min-w-0 shrink-0 px-3 focus:z-10 focus-visible:z-10",
+        "data-[spacing=0]:rounded-none data-[spacing=0]:shadow-none data-[spacing=0]:first:rounded-l-md data-[spacing=0]:last:rounded-r-md data-[spacing=0]:data-[variant=outline]:border-l-0 data-[spacing=0]:data-[variant=outline]:first:border-l",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  );
+}
+
+export { ToggleGroup, ToggleGroupItem };

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { cva, type VariantProps } from "class-variance-authority";
+import { Toggle as TogglePrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const toggleVariants = cva(
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-[color,box-shadow] outline-none hover:bg-muted hover:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline:
+          "border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-9 min-w-9 px-2",
+        sm: "h-8 min-w-8 px-1.5",
+        lg: "h-10 min-w-10 px-2.5",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+function Toggle({
+  className,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof TogglePrimitive.Root> &
+  VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive.Root
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Toggle, toggleVariants };


### PR DESCRIPTION
## Summary

- 追加と編集を 1 つの Dialog に統合し、ヘッダー右と空状態に CTA を集約。`ProgramForm` の平置きを撤去
- 一覧を Card 廃止 + `divide-y` のフラット構成に。番号・種別ラベル・時刻を整列、編集／削除は hover で控えめに浮かせる
- 種別 Select を `ToggleGroup`（shadcn 新規追加）に置き換え 1 クリック切替へ
- 演奏以外を選ぶと出演者欄を隠し、曲が 2 件以上あるときは `confirm` で警告
- 時刻 / 所要時間 / 備考を折りたたみ化（intermission と既存値ありは初期展開）
- 並び替え成功時に控えめな toast、required `*` を撤去、保存中は `fieldset` で全入力 disable
- バリデーション失敗時は該当入力へ scroll + focus、`aria-invalid` / `aria-describedby` を付与

## Test plan

- [x] `pnpm type-check`
- [x] `pnpm lint`
- [x] `pnpm vitest run`
- [x] preview emulator で `/events/:id/programs` を確認: 空状態 CTA / Dialog 統合 / ToggleGroup / 出演者欄の出し分け / 種別変更時の confirm（OK・キャンセル両方）/ 詳細折りたたみ / intermission 編集の自動展開 / 編集ダイアログ / AlertDialog 削除 / HTML5 required の auto focus
- [ ] 並び替え後の "並び順を保存しました" toast（`motion/react` Reorder のドラッグが playwright-cli 単発 drag では完了せず未確認）
- [ ] サーバー側 fieldErrors 経由の auto scroll + focus（HTML5 required で先に弾かれるため、Zod-only エラー経路で要確認）
- [ ] Storybook `Default` / `SingleItem` / `Empty` / `ReadOnly` の見た目
- [ ] キーボード操作（Tab 順 / Esc）
- [ ] devtools タッチエミュレーションでの編集・削除・drag
- [ ] `canModify=false`（finished イベント）で編集系 UI が一切出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)