### PR TITLE
ゲスト管理リネーム + 招待状にプログラム表示

### DIFF
--- a/src/app/_components/event-detail.tsx
+++ b/src/app/_components/event-detail.tsx
@@ -298,7 +298,7 @@ export function EventDetail({
           </Button>
           <Button variant="outline" asChild className="tracking-wider">
             <Link href={`/events/${event.id}/invitations`}>
-              <PendingLinkIndicator>招待管理</PendingLinkIndicator>
+              <PendingLinkIndicator>ゲスト管理</PendingLinkIndicator>
             </Link>
           </Button>
           <Button variant="outline" asChild className="tracking-wider">

--- a/src/app/_components/invitation-management.tsx
+++ b/src/app/_components/invitation-management.tsx
@@ -34,7 +34,7 @@ export function InvitationManagement({
   return (
     <div className="flex flex-col gap-8">
       <div>
-        <h1 className="text-3xl font-light tracking-wide">招待管理</h1>
+        <h1 className="text-3xl font-light tracking-wide">ゲスト管理</h1>
         <div className="mt-2 flex items-center gap-3">
           <span className="text-muted-foreground">{event.name}</span>
           <Badge variant={statusVariants[event.status]}>

--- a/src/app/_components/invitation-program-view.tsx
+++ b/src/app/_components/invitation-program-view.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { PROGRAM_TYPE_LABELS } from "@/db/schema";
+import type { ProgramWithPerformers } from "@/lib/queries/programs";
+import { cn } from "@/lib/utils";
+
+type InvitationProgramViewProps = {
+  programs: ProgramWithPerformers[];
+};
+
+export function InvitationProgramView({
+  programs,
+}: InvitationProgramViewProps) {
+  if (programs.length === 0) return null;
+
+  let performanceIndex = 0;
+  const performanceCount = programs.filter(
+    (p) => p.type === "performance",
+  ).length;
+
+  return (
+    <section className="border-t border-border/50 pt-2">
+      <Accordion type="single" collapsible defaultValue="program">
+        <AccordionItem value="program" className="border-b-0">
+          <AccordionTrigger className="py-4 hover:no-underline [&>svg]:text-muted-foreground">
+            <div className="flex items-baseline gap-3">
+              <span className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+                Program
+              </span>
+              <span className="text-xs tabular-nums text-muted-foreground/70">
+                全{performanceCount}演目
+              </span>
+            </div>
+          </AccordionTrigger>
+          <AccordionContent className="pb-0">
+            <ol className="flex flex-col divide-y divide-border/30 overflow-hidden rounded-md border border-border/40">
+              {programs.map((program) => {
+                const isPerformance = program.type === "performance";
+                if (isPerformance) performanceIndex += 1;
+                const timeLabel = program.scheduledTime ?? null;
+
+                return (
+                  <li
+                    key={program.id}
+                    className={cn(
+                      "flex items-start gap-3 px-3 py-3",
+                      !isPerformance && "bg-muted/30",
+                    )}
+                  >
+                    <span className="w-12 shrink-0">
+                      {isPerformance ? (
+                        <span className="mt-0.5 block text-sm font-medium tabular-nums text-muted-foreground">
+                          {performanceIndex}.
+                        </span>
+                      ) : program.type === "other" ? null : (
+                        <span className="mt-1 block text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
+                          {PROGRAM_TYPE_LABELS[program.type]}
+                        </span>
+                      )}
+                    </span>
+
+                    <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                      {isPerformance ? (
+                        <>
+                          {program.performers.length > 0 && (
+                            <span className="min-w-0 font-medium">
+                              {program.performers
+                                .map((p) => p.displayName)
+                                .join("、")}
+                            </span>
+                          )}
+                          {program.pieces.map((piece) => (
+                            <div
+                              key={piece.id}
+                              className="flex items-baseline gap-2 text-sm text-muted-foreground"
+                            >
+                              <span>{piece.title}</span>
+                              {piece.composer && (
+                                <span className="text-muted-foreground/60">
+                                  {piece.composer}
+                                </span>
+                              )}
+                            </div>
+                          ))}
+                        </>
+                      ) : (
+                        <span className="text-sm text-muted-foreground">
+                          {program.pieces[0]?.title ??
+                            PROGRAM_TYPE_LABELS[program.type]}
+                        </span>
+                      )}
+                    </div>
+
+                    {timeLabel && (
+                      <span className="mt-0.5 shrink-0 text-xs tabular-nums text-muted-foreground">
+                        {timeLabel}
+                      </span>
+                    )}
+                  </li>
+                );
+              })}
+            </ol>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    </section>
+  );
+}

--- a/src/app/_components/invitation-program-view.tsx
+++ b/src/app/_components/invitation-program-view.tsx
@@ -38,7 +38,7 @@ export function InvitationProgramView({
               </span>
             </div>
           </AccordionTrigger>
-          <AccordionContent className="pb-0">
+          <AccordionContent>
             <ol className="flex flex-col divide-y divide-border/30 overflow-hidden rounded-md border border-border/40">
               {programs.map((program) => {
                 const isPerformance = program.type === "performance";

--- a/src/app/_components/navigation-sheet.tsx
+++ b/src/app/_components/navigation-sheet.tsx
@@ -136,7 +136,7 @@ function EventNavItem({
   const subItems = useMemo(
     () => [
       { href: `${eventBase}`, label: "イベント詳細" },
-      { href: `${eventBase}/invitations`, label: "招待管理" },
+      { href: `${eventBase}/invitations`, label: "ゲスト管理" },
       { href: `${eventBase}/programs`, label: "プログラム管理" },
       { href: `${eventBase}/members`, label: "メンバー管理" },
       { href: `${eventBase}/checkin`, label: "チェックイン" },

--- a/src/app/_components/program-list.tsx
+++ b/src/app/_components/program-list.tsx
@@ -113,23 +113,30 @@ export function ProgramList({
       onReorder={handleReorder}
       className="flex flex-col divide-y divide-border/60 rounded-md border border-border/60 bg-card/40"
     >
-      {programs.map((program, index) => (
-        <ProgramRow
-          key={program.id}
-          program={program}
-          index={index}
-          canModify={canModify}
-          onEdit={onEdit}
-          onDelete={handleDelete}
-        />
-      ))}
+      {(() => {
+        let performanceCounter = 0;
+        return programs.map((program) => {
+          const performanceNumber =
+            program.type === "performance" ? ++performanceCounter : null;
+          return (
+            <ProgramRow
+              key={program.id}
+              program={program}
+              performanceNumber={performanceNumber}
+              canModify={canModify}
+              onEdit={onEdit}
+              onDelete={handleDelete}
+            />
+          );
+        });
+      })()}
     </Reorder.Group>
   );
 }
 
 type ProgramRowProps = {
   program: ProgramWithPerformers;
-  index: number;
+  performanceNumber: number | null;
   canModify: boolean;
   onEdit: (program: ProgramWithPerformers) => void;
   onDelete: (programId: string) => void;
@@ -137,7 +144,7 @@ type ProgramRowProps = {
 
 function ProgramRow({
   program,
-  index,
+  performanceNumber,
   canModify,
   onEdit,
   onDelete,
@@ -184,15 +191,17 @@ function ProgramRow({
         </button>
       )}
 
-      {program.type === "performance" ? (
-        <span className="mt-0.5 w-6 shrink-0 text-sm font-medium tabular-nums text-muted-foreground">
-          {index + 1}.
-        </span>
-      ) : (
-        <span className="mt-1 shrink-0 text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
-          {PROGRAM_TYPE_LABELS[program.type]}
-        </span>
-      )}
+      <span className="w-12 shrink-0">
+        {program.type === "performance" ? (
+          <span className="mt-0.5 block text-sm font-medium tabular-nums text-muted-foreground">
+            {performanceNumber}.
+          </span>
+        ) : program.type === "other" ? null : (
+          <span className="mt-1 block text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
+            {PROGRAM_TYPE_LABELS[program.type]}
+          </span>
+        )}
+      </span>
 
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
         {program.type === "performance" ? (

--- a/src/app/i/[token]/page.tsx
+++ b/src/app/i/[token]/page.tsx
@@ -301,7 +301,6 @@ export default async function InvitationResponsePage(
 
   const { event } = invitation;
   const isInvalidated = !!invitation.invalidatedAt;
-  const programs = await getProgramsByEventId(event.id);
 
   if (event.status === "draft") {
     return (
@@ -312,24 +311,8 @@ export default async function InvitationResponsePage(
     );
   }
 
-  // finished + accepted → 思い出カード
-  if (event.status === "finished") {
-    if (invitation.status === "accepted") {
-      return (
-        <GuestShell>
-          <EventInfoHeader
-            event={event}
-            inviterName={invitation.inviterDisplayName}
-          />
-          <InvitationProgramView programs={programs} />
-          <CurrentResponseView invitation={invitation} />
-          <CheckInStatusView invitation={invitation} />
-          <p className="border-t border-border/50 pt-6 text-xs tracking-wide text-muted-foreground">
-            このイベントは終了しました。お越しいただきありがとうございました
-          </p>
-        </GuestShell>
-      );
-    }
+  // finished + 非 accepted → 期限切れ
+  if (event.status === "finished" && invitation.status !== "accepted") {
     return (
       <ErrorView
         title="招待リンクの期限が切れました"
@@ -345,6 +328,27 @@ export default async function InvitationResponsePage(
         title="招待リンクは無効です"
         message="リンクに問題がある場合は、招待者にお問い合わせください"
       />
+    );
+  }
+
+  // 以降はプログラム表示があるため、ここで初めてフェッチ
+  const programs = await getProgramsByEventId(event.id);
+
+  // finished + accepted → 思い出カード
+  if (event.status === "finished") {
+    return (
+      <GuestShell>
+        <EventInfoHeader
+          event={event}
+          inviterName={invitation.inviterDisplayName}
+        />
+        <InvitationProgramView programs={programs} />
+        <CurrentResponseView invitation={invitation} />
+        <CheckInStatusView invitation={invitation} />
+        <p className="border-t border-border/50 pt-6 text-xs tracking-wide text-muted-foreground">
+          このイベントは終了しました。お越しいただきありがとうございました
+        </p>
+      </GuestShell>
     );
   }
 

--- a/src/app/i/[token]/page.tsx
+++ b/src/app/i/[token]/page.tsx
@@ -4,11 +4,13 @@ import {
   User,
   UsersThree,
 } from "@phosphor-icons/react/dist/ssr";
+import { InvitationProgramView } from "@/app/_components/invitation-program-view";
 import { InvitationResponseForm } from "@/app/_components/invitation-response-form";
 import { QrCode } from "@/app/_components/qr-code";
 import type { EventStatus } from "@/db/schema";
 import { formatDate, formatDatetime, formatTime } from "@/lib/format";
 import { getInvitationByToken } from "@/lib/queries/invitations";
+import { getProgramsByEventId } from "@/lib/queries/programs";
 
 // ============================================================
 // Shell
@@ -76,10 +78,14 @@ function EventInfoHeader({
 
       <dl className="grid grid-cols-[auto_1fr] items-baseline gap-x-6 gap-y-4 border-t border-border/50 pt-6 animate-in fade-in slide-in-from-bottom-2 duration-700 delay-150 motion-reduce:animate-none motion-reduce:delay-0">
         <dt className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
-          開演
+          会場
         </dt>
-        <dd className="text-sm tabular-nums">
-          {formatTime(event.startDatetime)}
+        <dd className="text-sm">
+          <span className="tabular-nums">
+            {formatDate(event.startDatetime)}
+          </span>
+          {" ／ "}
+          {event.venue}
         </dd>
         {event.openDatetime && (
           <>
@@ -92,14 +98,10 @@ function EventInfoHeader({
           </>
         )}
         <dt className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
-          会場
+          開演
         </dt>
-        <dd className="text-sm">
-          <span className="tabular-nums">
-            {formatDate(event.startDatetime)}
-          </span>
-          {" ／ "}
-          {event.venue}
+        <dd className="text-sm tabular-nums">
+          {formatTime(event.startDatetime)}
         </dd>
       </dl>
     </header>
@@ -299,6 +301,7 @@ export default async function InvitationResponsePage(
 
   const { event } = invitation;
   const isInvalidated = !!invitation.invalidatedAt;
+  const programs = await getProgramsByEventId(event.id);
 
   if (event.status === "draft") {
     return (
@@ -318,6 +321,7 @@ export default async function InvitationResponsePage(
             event={event}
             inviterName={invitation.inviterDisplayName}
           />
+          <InvitationProgramView programs={programs} />
           <CurrentResponseView invitation={invitation} />
           <CheckInStatusView invitation={invitation} />
           <p className="border-t border-border/50 pt-6 text-xs tracking-wide text-muted-foreground">
@@ -372,6 +376,8 @@ export default async function InvitationResponsePage(
         event={event}
         inviterName={invitation.inviterDisplayName}
       />
+
+      <InvitationProgramView programs={programs} />
 
       {showPass && (
         <div className="animate-in fade-in slide-in-from-bottom-2 duration-700 delay-300 motion-reduce:animate-none motion-reduce:delay-0">

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -55,10 +55,13 @@ function AccordionContent({
   return (
     <AccordionPrimitive.Content
       data-slot="accordion-content"
-      className="overflow-hidden text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+      className={cn(
+        "overflow-hidden text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down",
+        className,
+      )}
       {...props}
     >
-      <div className={cn("pt-0 pb-4", className)}>{children}</div>
+      <div className="pt-0 pb-4">{children}</div>
     </AccordionPrimitive.Content>
   );
 }

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { CaretDown } from "@phosphor-icons/react";
+import { Accordion as AccordionPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Accordion({
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Root>) {
+  return <AccordionPrimitive.Root data-slot="accordion" {...props} />;
+}
+
+function AccordionItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Item>) {
+  return (
+    <AccordionPrimitive.Item
+      data-slot="accordion-item"
+      className={cn("border-b last:border-b-0", className)}
+      {...props}
+    />
+  );
+}
+
+function AccordionTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
+  return (
+    <AccordionPrimitive.Header className="flex">
+      <AccordionPrimitive.Trigger
+        data-slot="accordion-trigger"
+        className={cn(
+          "flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <CaretDown className="pointer-events-none size-4 shrink-0 translate-y-0.5 text-muted-foreground transition-transform duration-200" />
+      </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+  );
+}
+
+function AccordionContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Content>) {
+  return (
+    <AccordionPrimitive.Content
+      data-slot="accordion-content"
+      className="overflow-hidden text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+      {...props}
+    >
+      <div className={cn("pt-0 pb-4", className)}>{children}</div>
+    </AccordionPrimitive.Content>
+  );
+}
+
+export { Accordion, AccordionContent, AccordionItem, AccordionTrigger };


### PR DESCRIPTION
## Summary
- 「招待管理」を「ゲスト管理」にラベル変更（URL や DB は据え置き）
- ゲスト招待状に演目プログラムをアコーディオンで表示（折りたたみ可能、デフォルト展開）
- 招待状のイベント情報を「会場 → 開場 → 開演」の順に整理
- プログラム管理と招待状で視覚言語を揃える: 演目番号を演奏のみカウント・左添字幅を統一・その他は無ラベル

## コミット構成
1. \`refactor: 「招待管理」を「ゲスト管理」にラベル変更\`
2. \`feat(invitation): 招待状にプログラム表示を追加し、イベント情報の並び順を調整\`
3. \`refactor(programs): 演目番号を演奏のみカウントし、左添字幅を統一\`

## Test plan
- [ ] イベント詳細・ナビゲーションで「ゲスト管理」と表示される
- [ ] 招待状（\`/i/[token]\`）でプログラムがアコーディオンで表示される
- [ ] アコーディオン開閉が動作する
- [ ] 招待状のイベント情報が「会場 → 開場 → 開演」順
- [ ] プログラム管理画面で演目番号が休憩を挟んでも飛ばない
- [ ] 演目・休憩・あいさつ・その他で本文開始位置が揃う
- [ ] その他種別の左カラムに「その他」ラベルが出ない
- [ ] type-check / lint / vitest 全 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)