### PR TITLE
refactor(event-detail): イベント詳細を数値付きの管理ハブに再構成

### DIFF
--- a/src/app/(main)/events/[eventId]/page.tsx
+++ b/src/app/(main)/events/[eventId]/page.tsx
@@ -2,7 +2,11 @@ import { notFound } from "next/navigation";
 import { EventDetail } from "@/app/_components/event-detail";
 import { HeaderConfig } from "@/app/_components/header-config";
 import { VALID_TRANSITIONS } from "@/db/schema";
-import { getEventDetail, getEventMembership } from "@/lib/queries/events";
+import {
+  getEventDetail,
+  getEventMembership,
+  getEventStats,
+} from "@/lib/queries/events";
 import { requireSession } from "@/lib/session";
 
 export default async function EventDetailPage(
@@ -16,7 +20,10 @@ export default async function EventDetailPage(
     notFound();
   }
 
-  const event = await getEventDetail(eventId);
+  const [event, stats] = await Promise.all([
+    getEventDetail(eventId),
+    getEventStats(eventId),
+  ]);
   if (!event) {
     notFound();
   }
@@ -28,6 +35,7 @@ export default async function EventDetailPage(
       <HeaderConfig showBackButton />
       <EventDetail
         event={event}
+        stats={stats}
         currentUserRole={member.role}
         availableTransitions={availableTransitions}
       />

--- a/src/app/_components/event-detail.tsx
+++ b/src/app/_components/event-detail.tsx
@@ -10,7 +10,7 @@ import {
   Users,
 } from "@phosphor-icons/react";
 import Link from "next/link";
-import { useActionState, useState, useTransition } from "react";
+import { type ReactNode, useActionState, useState, useTransition } from "react";
 import { toast } from "sonner";
 import { PendingLinkIndicator } from "@/app/_components/pending-link-indicator";
 import {
@@ -403,7 +403,7 @@ function FactItem({
   value,
   sub,
 }: {
-  icon: React.ReactNode;
+  icon: ReactNode;
   label: string;
   value: string;
   sub?: string | null;
@@ -431,7 +431,7 @@ function ManageTile({
   hint,
 }: {
   href: string;
-  icon: React.ReactNode;
+  icon: ReactNode;
   label: string;
   primary: string;
   hint: string;

--- a/src/app/_components/event-detail.tsx
+++ b/src/app/_components/event-detail.tsx
@@ -409,7 +409,8 @@ function FactItem({
   sub?: string | null;
 }) {
   return (
-    <div className="flex flex-col gap-1.5">
+    // biome-ignore lint/a11y/useSemanticElements: <dl> の子として <fieldset> は使えないため、name-value group のラッパとして div + role="group" を採用
+    <div role="group" className="flex flex-col gap-1.5">
       <dt className="flex items-center gap-2 text-muted-foreground text-xs tracking-[0.2em] uppercase">
         <span className="text-foreground/60">{icon}</span>
         {label}

--- a/src/app/_components/event-detail.tsx
+++ b/src/app/_components/event-detail.tsx
@@ -1,5 +1,14 @@
 "use client";
 
+import {
+  CalendarBlank,
+  CaretRight,
+  IdentificationCard,
+  MapPin,
+  MusicNotes,
+  Scan,
+  Users,
+} from "@phosphor-icons/react";
 import Link from "next/link";
 import { useActionState, useState, useTransition } from "react";
 import { toast } from "sonner";
@@ -22,9 +31,15 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
 import type { EventStatus, MemberRole } from "@/db/schema";
 import {
   statusLabels,
@@ -32,6 +47,7 @@ import {
   transitionLabels,
 } from "@/lib/event-status";
 import { formatDatetime } from "@/lib/format";
+import type { EventStats } from "@/lib/queries/events";
 
 type EventDetailProps = {
   event: {
@@ -49,12 +65,14 @@ type EventDetailProps = {
       user: { id: string; name: string; image: string | null };
     }>;
   };
+  stats: EventStats;
   currentUserRole: MemberRole;
   availableTransitions: EventStatus[];
 };
 
 export function EventDetail({
   event,
+  stats,
   currentUserRole,
   availableTransitions,
 }: EventDetailProps) {
@@ -79,6 +97,8 @@ export function EventDetail({
   const isOrganizer = currentUserRole === "organizer";
   const canEdit =
     isOrganizer && (event.status === "draft" || event.status === "published");
+  const canDelete =
+    isOrganizer && (event.status === "draft" || event.status === "finished");
 
   const handleStatusChange = (newStatus: EventStatus) => {
     startTransition(async () => {
@@ -102,68 +122,73 @@ export function EventDetail({
   };
 
   return (
-    <div className="flex flex-col gap-8">
-      {/* ヘッダー */}
-      <div className="flex items-start justify-between">
-        <div>
-          <h1 className="text-3xl font-light tracking-wide">{event.name}</h1>
-          <div className="mt-2 flex items-center gap-3">
-            <Badge variant={statusVariants[event.status]}>
+    <div className="flex flex-col gap-10">
+      {/* ヒーロー */}
+      <header className="flex flex-col gap-6">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex flex-col gap-3">
+            <Badge
+              variant={statusVariants[event.status]}
+              className="w-fit tracking-[0.18em] uppercase"
+            >
               {statusLabels[event.status]}
             </Badge>
+            <h1 className="font-light text-3xl tracking-wide leading-tight md:text-4xl">
+              {event.name}
+            </h1>
           </div>
+          {canEdit && !isEditing && (
+            <Button
+              variant="outline"
+              onClick={() => setIsEditing(true)}
+              className="tracking-wider"
+            >
+              編集
+            </Button>
+          )}
+          {canEdit && isEditing && (
+            <Button
+              variant="ghost"
+              onClick={() => setIsEditing(false)}
+              className="tracking-wider"
+            >
+              キャンセル
+            </Button>
+          )}
         </div>
-        {canEdit && (
-          <Button variant="outline" onClick={() => setIsEditing(!isEditing)}>
-            {isEditing ? "キャンセル" : "編集"}
-          </Button>
+
+        {!isEditing && (
+          <dl className="grid gap-6 border-border/60 border-y py-6 md:grid-cols-3">
+            <FactItem
+              icon={<CalendarBlank className="h-4 w-4" aria-hidden />}
+              label="開演"
+              value={formatDatetime(event.startDatetime)}
+              sub={
+                event.openDatetime
+                  ? `開場 ${formatDatetime(event.openDatetime)}`
+                  : null
+              }
+            />
+            <FactItem
+              icon={<MapPin className="h-4 w-4" aria-hidden />}
+              label="会場"
+              value={event.venue}
+            />
+            <FactItem
+              icon={<IdentificationCard className="h-4 w-4" aria-hidden />}
+              label="座席"
+              value={
+                event.totalSeats === 0 ? "無制限" : `${event.totalSeats} 席`
+              }
+            />
+          </dl>
         )}
-      </div>
+      </header>
 
-      {/* イベント情報 — 閲覧モード */}
-      {!isEditing && (
-        <Card>
-          <CardContent className="space-y-4 pt-6">
-            <div>
-              <p className="text-xs tracking-[0.2em] uppercase text-muted-foreground">
-                開催日時
-              </p>
-              <p className="leading-relaxed">
-                {formatDatetime(event.startDatetime)}
-              </p>
-            </div>
-            {event.openDatetime && (
-              <div>
-                <p className="text-xs tracking-[0.2em] uppercase text-muted-foreground">
-                  開場
-                </p>
-                <p className="leading-relaxed">
-                  {formatDatetime(event.openDatetime)}
-                </p>
-              </div>
-            )}
-            <div>
-              <p className="text-xs tracking-[0.2em] uppercase text-muted-foreground">
-                会場
-              </p>
-              <p className="leading-relaxed">{event.venue}</p>
-            </div>
-            <div>
-              <p className="text-xs tracking-[0.2em] uppercase text-muted-foreground">
-                座席数
-              </p>
-              <p className="leading-relaxed">
-                {event.totalSeats === 0 ? "無制限" : `${event.totalSeats} 席`}
-              </p>
-            </div>
-          </CardContent>
-        </Card>
-      )}
-
-      {/* イベント情報 — 編集モード */}
+      {/* 編集モード */}
       {isEditing && (
         <div className="rounded-sm border border-border/50 bg-card p-8">
-          <h2 className="mb-6 font-serif text-lg font-light text-foreground">
+          <h2 className="mb-6 font-light font-serif text-foreground text-lg">
             イベント情報を編集
           </h2>
 
@@ -254,91 +279,197 @@ export function EventDetail({
         </div>
       )}
 
-      {/* ステータス変更（主催者のみ） */}
-      {isOrganizer && availableTransitions.length > 0 && (
-        <Card>
-          <CardHeader>
-            <CardTitle className="font-light tracking-wide text-lg">
-              ステータス変更
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="flex gap-3">
-            {availableTransitions.map((next) => (
-              <Button
-                key={next}
-                variant="outline"
-                disabled={isPending}
-                onClick={() => handleStatusChange(next)}
-                className="tracking-wider"
-              >
-                {transitionLabels[next]}
-              </Button>
-            ))}
-          </CardContent>
-        </Card>
+      {/* 管理ハブ */}
+      {!isEditing && (
+        <section className="flex flex-col gap-4">
+          <div className="flex items-baseline justify-between">
+            <h2 className="text-xs uppercase text-muted-foreground tracking-[0.24em]">
+              管理
+            </h2>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <ManageTile
+              href={`/events/${event.id}/programs`}
+              icon={<MusicNotes className="h-4 w-4" aria-hidden />}
+              label="プログラム"
+              primary={`${stats.programCount} 件`}
+              hint="演目・休憩・あいさつ"
+            />
+            <ManageTile
+              href={`/events/${event.id}/members`}
+              icon={<IdentificationCard className="h-4 w-4" aria-hidden />}
+              label="メンバー"
+              primary={`${stats.performerCount} 名`}
+              hint="出演者の一覧と招待"
+            />
+            <ManageTile
+              href={`/events/${event.id}/invitations`}
+              icon={<Users className="h-4 w-4" aria-hidden />}
+              label="ゲスト"
+              primary={
+                stats.invitationTotal === 0
+                  ? "未発行"
+                  : `${stats.invitationAccepted} / ${stats.invitationTotal} 出席`
+              }
+              hint={
+                stats.invitationPending > 0
+                  ? `未回答 ${stats.invitationPending} 件`
+                  : "全員回答済"
+              }
+            />
+            <ManageTile
+              href={`/events/${event.id}/checkin`}
+              icon={<Scan className="h-4 w-4" aria-hidden />}
+              label="チェックイン"
+              primary={
+                stats.invitationAccepted === 0
+                  ? "受付なし"
+                  : `${stats.totalAttendees} 名 来場`
+              }
+              hint={
+                stats.invitationAccepted === 0
+                  ? "出席者が確定したら受付できます"
+                  : `出席予定 ${stats.invitationAccepted} 名`
+              }
+            />
+          </div>
+        </section>
       )}
 
-      {/* 管理メニュー（後続で実装するページへのリンク） */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="font-light tracking-wide text-lg">
-            管理
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="flex flex-col gap-3">
-          <Button variant="outline" asChild className="tracking-wider">
-            <Link href={`/events/${event.id}/programs`}>
-              <PendingLinkIndicator>プログラム管理</PendingLinkIndicator>
-            </Link>
-          </Button>
-          <Button variant="outline" asChild className="tracking-wider">
-            <Link href={`/events/${event.id}/members`}>
-              <PendingLinkIndicator>メンバー管理</PendingLinkIndicator>
-            </Link>
-          </Button>
-          <Button variant="outline" asChild className="tracking-wider">
-            <Link href={`/events/${event.id}/invitations`}>
-              <PendingLinkIndicator>ゲスト管理</PendingLinkIndicator>
-            </Link>
-          </Button>
-          <Button variant="outline" asChild className="tracking-wider">
-            <Link href={`/events/${event.id}/checkin`}>
-              <PendingLinkIndicator>チェックイン</PendingLinkIndicator>
-            </Link>
-          </Button>
-        </CardContent>
-      </Card>
+      {/* 二次アクション */}
+      {!isEditing && isOrganizer && availableTransitions.length > 0 && (
+        <Collapsible>
+          <Card className="border-dashed">
+            <CardContent className="p-0">
+              <CollapsibleTrigger asChild>
+                <button
+                  type="button"
+                  className="group flex w-full items-center justify-between gap-3 px-5 py-4 text-left text-sm tracking-wider transition-colors hover:bg-muted/40"
+                >
+                  <span className="text-muted-foreground">
+                    ステータスを変更
+                  </span>
+                  <CaretRight className="h-4 w-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-90" />
+                </button>
+              </CollapsibleTrigger>
+              <CollapsibleContent>
+                <Separator />
+                <div className="flex flex-wrap gap-2 px-5 py-4">
+                  {availableTransitions.map((next) => (
+                    <Button
+                      key={next}
+                      variant="outline"
+                      size="sm"
+                      disabled={isPending}
+                      onClick={() => handleStatusChange(next)}
+                      className="tracking-wider"
+                    >
+                      {transitionLabels[next]}
+                    </Button>
+                  ))}
+                </div>
+              </CollapsibleContent>
+            </CardContent>
+          </Card>
+        </Collapsible>
+      )}
 
-      {/* 削除（主催者 + draft/finished のみ） */}
-      {isOrganizer &&
-        (event.status === "draft" || event.status === "finished") && (
-          <div className="pt-4 border-t">
-            <AlertDialog>
-              <AlertDialogTrigger asChild>
-                <Button variant="destructive">イベントを削除</Button>
-              </AlertDialogTrigger>
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>イベントを削除しますか？</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    {event.status === "finished"
-                      ? `「${event.name}」のすべてのデータ（招待・チェックイン記録・プログラム情報）が完全に削除されます。この操作は元に戻せません。`
-                      : `「${event.name}」を削除すると、関連するメンバー・招待・プログラム情報もすべて削除されます。この操作は元に戻せません。`}
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>キャンセル</AlertDialogCancel>
-                  <AlertDialogAction
-                    onClick={handleDelete}
-                    disabled={isPending}
-                  >
-                    {isPending ? "削除中..." : "削除する"}
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
-          </div>
-        )}
+      {/* Danger Zone */}
+      {!isEditing && canDelete && (
+        <div className="mt-2 flex items-center justify-between gap-4 border-border/40 border-t pt-6">
+          <p className="text-muted-foreground text-xs tracking-[0.18em] uppercase">
+            このイベントを削除
+          </p>
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button variant="ghost" size="sm" className="text-destructive">
+                削除
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>イベントを削除しますか？</AlertDialogTitle>
+                <AlertDialogDescription>
+                  {event.status === "finished"
+                    ? `「${event.name}」のすべてのデータ（招待・チェックイン記録・プログラム情報）が完全に削除されます。この操作は元に戻せません。`
+                    : `「${event.name}」を削除すると、関連するメンバー・招待・プログラム情報もすべて削除されます。この操作は元に戻せません。`}
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>キャンセル</AlertDialogCancel>
+                <AlertDialogAction onClick={handleDelete} disabled={isPending}>
+                  {isPending ? "削除中..." : "削除する"}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
+      )}
     </div>
+  );
+}
+
+function FactItem({
+  icon,
+  label,
+  value,
+  sub,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  sub?: string | null;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <dt className="flex items-center gap-2 text-muted-foreground text-xs tracking-[0.2em] uppercase">
+        <span className="text-foreground/60">{icon}</span>
+        {label}
+      </dt>
+      <dd className="font-light text-base leading-relaxed">{value}</dd>
+      {sub && (
+        <dd className="text-muted-foreground text-xs tracking-wide">{sub}</dd>
+      )}
+    </div>
+  );
+}
+
+function ManageTile({
+  href,
+  icon,
+  label,
+  primary,
+  hint,
+}: {
+  href: string;
+  icon: React.ReactNode;
+  label: string;
+  primary: string;
+  hint: string;
+}) {
+  return (
+    <Link
+      href={href}
+      className="group relative flex flex-col gap-3 rounded-sm border border-border/60 bg-card p-5 transition-colors hover:border-foreground/40 hover:bg-muted/30"
+    >
+      <div className="flex items-center justify-between">
+        <span className="flex items-center gap-2 text-muted-foreground text-xs tracking-[0.2em] uppercase">
+          <span className="text-foreground/60">{icon}</span>
+          <PendingLinkIndicator>{label}</PendingLinkIndicator>
+        </span>
+        <CaretRight
+          className="h-4 w-4 text-muted-foreground transition-transform group-hover:translate-x-0.5"
+          aria-hidden
+        />
+      </div>
+      <div className="flex flex-col gap-0.5">
+        <span className="font-light text-foreground text-xl tracking-wide">
+          {primary}
+        </span>
+        <span className="text-muted-foreground text-xs tracking-wide">
+          {hint}
+        </span>
+      </div>
+    </Link>
   );
 }

--- a/src/app/_components/event-detail.tsx
+++ b/src/app/_components/event-detail.tsx
@@ -31,7 +31,6 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
 import {
   Collapsible,
   CollapsibleContent,
@@ -338,39 +337,28 @@ export function EventDetail({
 
       {/* 二次アクション */}
       {!isEditing && isOrganizer && availableTransitions.length > 0 && (
-        <Collapsible>
-          <Card className="border-dashed">
-            <CardContent className="p-0">
-              <CollapsibleTrigger asChild>
-                <button
-                  type="button"
-                  className="group flex w-full items-center justify-between gap-3 px-5 py-4 text-left text-sm tracking-wider transition-colors hover:bg-muted/40"
+        <Collapsible className="rounded-sm border border-border/60 border-dashed">
+          <CollapsibleTrigger className="group flex w-full items-center justify-between gap-3 px-5 py-4 text-left text-sm tracking-wider transition-colors hover:bg-muted/40">
+            <span className="text-muted-foreground">ステータスを変更</span>
+            <CaretRight className="h-4 w-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-90" />
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <Separator />
+            <div className="flex flex-wrap gap-2 px-5 py-4">
+              {availableTransitions.map((next) => (
+                <Button
+                  key={next}
+                  variant="outline"
+                  size="sm"
+                  disabled={isPending}
+                  onClick={() => handleStatusChange(next)}
+                  className="tracking-wider"
                 >
-                  <span className="text-muted-foreground">
-                    ステータスを変更
-                  </span>
-                  <CaretRight className="h-4 w-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-90" />
-                </button>
-              </CollapsibleTrigger>
-              <CollapsibleContent>
-                <Separator />
-                <div className="flex flex-wrap gap-2 px-5 py-4">
-                  {availableTransitions.map((next) => (
-                    <Button
-                      key={next}
-                      variant="outline"
-                      size="sm"
-                      disabled={isPending}
-                      onClick={() => handleStatusChange(next)}
-                      className="tracking-wider"
-                    >
-                      {transitionLabels[next]}
-                    </Button>
-                  ))}
-                </div>
-              </CollapsibleContent>
-            </CardContent>
-          </Card>
+                  {transitionLabels[next]}
+                </Button>
+              ))}
+            </div>
+          </CollapsibleContent>
         </Collapsible>
       )}
 

--- a/src/app/_components/event-detail.tsx
+++ b/src/app/_components/event-detail.tsx
@@ -57,12 +57,6 @@ type EventDetailProps = {
     openDatetime: string | null;
     status: EventStatus;
     totalSeats: number;
-    eventMembers: Array<{
-      id: string;
-      role: MemberRole;
-      displayName: string;
-      user: { id: string; name: string; image: string | null };
-    }>;
   };
   stats: EventStats;
   currentUserRole: MemberRole;
@@ -279,61 +273,7 @@ export function EventDetail({
       )}
 
       {/* 管理ハブ */}
-      {!isEditing && (
-        <section className="flex flex-col gap-4">
-          <div className="flex items-baseline justify-between">
-            <h2 className="text-xs uppercase text-muted-foreground tracking-[0.24em]">
-              管理
-            </h2>
-          </div>
-          <div className="grid gap-3 sm:grid-cols-2">
-            <ManageTile
-              href={`/events/${event.id}/programs`}
-              icon={<MusicNotes className="h-4 w-4" aria-hidden />}
-              label="プログラム"
-              primary={`${stats.programCount} 件`}
-              hint="演目・休憩・あいさつ"
-            />
-            <ManageTile
-              href={`/events/${event.id}/members`}
-              icon={<IdentificationCard className="h-4 w-4" aria-hidden />}
-              label="メンバー"
-              primary={`${stats.performerCount} 名`}
-              hint="出演者の一覧と招待"
-            />
-            <ManageTile
-              href={`/events/${event.id}/invitations`}
-              icon={<Users className="h-4 w-4" aria-hidden />}
-              label="ゲスト"
-              primary={
-                stats.invitationTotal === 0
-                  ? "未発行"
-                  : `${stats.invitationAccepted} / ${stats.invitationTotal} 出席`
-              }
-              hint={
-                stats.invitationPending > 0
-                  ? `未回答 ${stats.invitationPending} 件`
-                  : "全員回答済"
-              }
-            />
-            <ManageTile
-              href={`/events/${event.id}/checkin`}
-              icon={<Scan className="h-4 w-4" aria-hidden />}
-              label="チェックイン"
-              primary={
-                stats.invitationAccepted === 0
-                  ? "受付なし"
-                  : `${stats.totalAttendees} 名 来場`
-              }
-              hint={
-                stats.invitationAccepted === 0
-                  ? "出席者が確定したら受付できます"
-                  : `出席予定 ${stats.invitationAccepted} 名`
-              }
-            />
-          </div>
-        </section>
-      )}
+      {!isEditing && <ManageHub eventId={event.id} stats={stats} />}
 
       {/* 二次アクション */}
       {!isEditing && isOrganizer && availableTransitions.length > 0 && (
@@ -420,6 +360,62 @@ function FactItem({
         <dd className="text-muted-foreground text-xs tracking-wide">{sub}</dd>
       )}
     </div>
+  );
+}
+
+function ManageHub({ eventId, stats }: { eventId: string; stats: EventStats }) {
+  const hasInvitations = stats.invitationTotal > 0;
+  const hasAccepted = stats.invitationAccepted > 0;
+  const hasPending = stats.invitationPending > 0;
+
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex items-baseline justify-between">
+        <h2 className="text-xs uppercase text-muted-foreground tracking-[0.24em]">
+          管理
+        </h2>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <ManageTile
+          href={`/events/${eventId}/programs`}
+          icon={<MusicNotes className="h-4 w-4" aria-hidden />}
+          label="プログラム"
+          primary={`${stats.programCount} 件`}
+          hint="演目・休憩・あいさつ"
+        />
+        <ManageTile
+          href={`/events/${eventId}/members`}
+          icon={<IdentificationCard className="h-4 w-4" aria-hidden />}
+          label="メンバー"
+          primary={`${stats.performerCount} 名`}
+          hint="出演者の一覧と招待"
+        />
+        <ManageTile
+          href={`/events/${eventId}/invitations`}
+          icon={<Users className="h-4 w-4" aria-hidden />}
+          label="ゲスト"
+          primary={
+            hasInvitations
+              ? `${stats.invitationAccepted} / ${stats.invitationTotal} 出席`
+              : "未発行"
+          }
+          hint={
+            hasPending ? `未回答 ${stats.invitationPending} 件` : "全員回答済"
+          }
+        />
+        <ManageTile
+          href={`/events/${eventId}/checkin`}
+          icon={<Scan className="h-4 w-4" aria-hidden />}
+          label="チェックイン"
+          primary={hasAccepted ? `${stats.totalAttendees} 名 来場` : "受付なし"}
+          hint={
+            hasAccepted
+              ? `出席予定 ${stats.invitationAccepted} 名`
+              : "出席者が確定したら受付できます"
+          }
+        />
+      </div>
+    </section>
   );
 }
 

--- a/src/lib/queries/events.ts
+++ b/src/lib/queries/events.ts
@@ -115,51 +115,59 @@ export type EventStats = {
  * - 管理メニューのタイルに各エリアの現在値を表示するために使う
  */
 export async function getEventStats(eventId: string): Promise<EventStats> {
-  const programStats = await db
-    .select({ total: count() })
-    .from(programs)
-    .where(eq(programs.eventId, eventId))
-    .get();
-
-  const performerStats = await db
-    .select({ total: count() })
-    .from(eventMembers)
-    .where(
-      and(
-        eq(eventMembers.eventId, eventId),
-        eq(eventMembers.role, "performer"),
-      ),
-    )
-    .get();
-
-  const invitationStats = await db
-    .select({
-      total: count(),
-      accepted: count(
-        sql`CASE WHEN ${invitations.status} = 'accepted' THEN 1 END`,
-      ),
-      pending: count(
-        sql`CASE WHEN ${invitations.status} = 'pending' THEN 1 END`,
-      ),
-      declined: count(
-        sql`CASE WHEN ${invitations.status} = 'declined' THEN 1 END`,
-      ),
-      checkedInGuests: count(
-        sql`CASE WHEN ${invitations.checkedIn} = 1 THEN 1 END`,
-      ),
-    })
-    .from(invitations)
-    .where(eq(invitations.eventId, eventId))
-    .get();
-
-  const companionStats = await db
-    .select({
-      checkedIn: count(sql`CASE WHEN ${companions.checkedIn} = 1 THEN 1 END`),
-    })
-    .from(companions)
-    .innerJoin(invitations, eq(companions.invitationId, invitations.id))
-    .where(eq(invitations.eventId, eventId))
-    .get();
+  const [programStats, performerStats, invitationStats, companionStats] =
+    await Promise.all([
+      db
+        .select({ total: count() })
+        .from(programs)
+        .where(eq(programs.eventId, eventId))
+        .get(),
+      db
+        .select({ total: count() })
+        .from(eventMembers)
+        .where(
+          and(
+            eq(eventMembers.eventId, eventId),
+            eq(eventMembers.role, "performer"),
+          ),
+        )
+        .get(),
+      db
+        .select({
+          total: count(),
+          accepted: count(
+            sql`CASE WHEN ${invitations.status} = 'accepted' THEN 1 END`,
+          ),
+          pending: count(
+            sql`CASE WHEN ${invitations.status} = 'pending' THEN 1 END`,
+          ),
+          declined: count(
+            sql`CASE WHEN ${invitations.status} = 'declined' THEN 1 END`,
+          ),
+          // チェックインは accepted のみ対象（getCheckInSummary と整合）
+          checkedInGuests: count(
+            sql`CASE WHEN ${invitations.status} = 'accepted' AND ${invitations.checkedIn} = 1 THEN 1 END`,
+          ),
+        })
+        .from(invitations)
+        .where(eq(invitations.eventId, eventId))
+        .get(),
+      db
+        .select({
+          checkedIn: count(
+            sql`CASE WHEN ${companions.checkedIn} = 1 THEN 1 END`,
+          ),
+        })
+        .from(companions)
+        .innerJoin(invitations, eq(companions.invitationId, invitations.id))
+        .where(
+          and(
+            eq(invitations.eventId, eventId),
+            eq(invitations.status, "accepted"),
+          ),
+        )
+        .get(),
+    ]);
 
   const checkedInGuests = invitationStats?.checkedInGuests ?? 0;
   const checkedInCompanions = companionStats?.checkedIn ?? 0;

--- a/src/lib/queries/events.ts
+++ b/src/lib/queries/events.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { and, asc, count, desc, eq, ne, sql } from "drizzle-orm";
+import { and, asc, count, desc, eq, isNull, ne, sql } from "drizzle-orm";
 import { cache } from "react";
 import { db } from "@/db";
 import type { EventStatus, MemberRole } from "@/db/schema";
@@ -150,7 +150,13 @@ export async function getEventStats(eventId: string): Promise<EventStats> {
           ),
         })
         .from(invitations)
-        .where(eq(invitations.eventId, eventId))
+        // 無効化済み招待は管理ハブの分母・回答状況集計から除外（SeatSummaryCard と整合）
+        .where(
+          and(
+            eq(invitations.eventId, eventId),
+            isNull(invitations.invalidatedAt),
+          ),
+        )
         .get(),
       db
         .select({
@@ -164,6 +170,7 @@ export async function getEventStats(eventId: string): Promise<EventStats> {
           and(
             eq(invitations.eventId, eventId),
             eq(invitations.status, "accepted"),
+            isNull(invitations.invalidatedAt),
           ),
         )
         .get(),

--- a/src/lib/queries/events.ts
+++ b/src/lib/queries/events.ts
@@ -85,16 +85,11 @@ export const getEventsByUserId = cache(
 );
 
 /**
- * イベント詳細を取得（メンバー情報含む）
+ * イベント詳細を取得
  */
 export async function getEventDetail(eventId: string) {
   return db.query.events.findFirst({
     where: eq(events.id, eventId),
-    with: {
-      eventMembers: {
-        with: { user: true },
-      },
-    },
   });
 }
 

--- a/src/lib/queries/events.ts
+++ b/src/lib/queries/events.ts
@@ -1,10 +1,16 @@
 import "server-only";
 
-import { and, asc, desc, eq, ne } from "drizzle-orm";
+import { and, asc, count, desc, eq, ne, sql } from "drizzle-orm";
 import { cache } from "react";
 import { db } from "@/db";
 import type { EventStatus, MemberRole } from "@/db/schema";
-import { eventMembers, events } from "@/db/schema";
+import {
+  companions,
+  eventMembers,
+  events,
+  invitations,
+  programs,
+} from "@/db/schema";
 
 export type EventWithRole = {
   id: string;
@@ -90,6 +96,85 @@ export async function getEventDetail(eventId: string) {
       },
     },
   });
+}
+
+export type EventStats = {
+  programCount: number;
+  performerCount: number;
+  invitationTotal: number;
+  invitationAccepted: number;
+  invitationPending: number;
+  invitationDeclined: number;
+  checkedInGuests: number;
+  checkedInCompanions: number;
+  totalAttendees: number;
+};
+
+/**
+ * イベント詳細画面のサマリ集計
+ * - 管理メニューのタイルに各エリアの現在値を表示するために使う
+ */
+export async function getEventStats(eventId: string): Promise<EventStats> {
+  const programStats = await db
+    .select({ total: count() })
+    .from(programs)
+    .where(eq(programs.eventId, eventId))
+    .get();
+
+  const performerStats = await db
+    .select({ total: count() })
+    .from(eventMembers)
+    .where(
+      and(
+        eq(eventMembers.eventId, eventId),
+        eq(eventMembers.role, "performer"),
+      ),
+    )
+    .get();
+
+  const invitationStats = await db
+    .select({
+      total: count(),
+      accepted: count(
+        sql`CASE WHEN ${invitations.status} = 'accepted' THEN 1 END`,
+      ),
+      pending: count(
+        sql`CASE WHEN ${invitations.status} = 'pending' THEN 1 END`,
+      ),
+      declined: count(
+        sql`CASE WHEN ${invitations.status} = 'declined' THEN 1 END`,
+      ),
+      checkedInGuests: count(
+        sql`CASE WHEN ${invitations.checkedIn} = 1 THEN 1 END`,
+      ),
+    })
+    .from(invitations)
+    .where(eq(invitations.eventId, eventId))
+    .get();
+
+  const companionStats = await db
+    .select({
+      checkedIn: count(sql`CASE WHEN ${companions.checkedIn} = 1 THEN 1 END`),
+    })
+    .from(companions)
+    .innerJoin(invitations, eq(companions.invitationId, invitations.id))
+    .where(eq(invitations.eventId, eventId))
+    .get();
+
+  const checkedInGuests = invitationStats?.checkedInGuests ?? 0;
+  const checkedInCompanions = companionStats?.checkedIn ?? 0;
+
+  return {
+    programCount: programStats?.total ?? 0,
+    performerCount: performerStats?.total ?? 0,
+    invitationTotal: invitationStats?.total ?? 0,
+    invitationAccepted: invitationStats?.accepted ?? 0,
+    invitationPending: invitationStats?.pending ?? 0,
+    invitationDeclined: invitationStats?.declined ?? 0,
+    checkedInGuests,
+    checkedInCompanions,
+    totalAttendees: checkedInGuests + checkedInCompanions,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary
- イベント詳細ページのレイアウトを「ヒーロー → 管理タイル(2×2) → 折りたたみステータス変更 → Danger Zone」に再構成
- `getEventStats` を新設し、各管理タイルに**現在値**（プログラム数 / 出演者数 / ゲスト出席状況 / チェックイン来場数）を表示
- ステータス変更を Collapsible に、削除を ghost ボタンの Danger Zone に格下げし、主要動線を阻害しないように

## Why
管理画面なのに、各管理ページへのボタンがただのナビゲーションになっていて状況が一目で掴めなかった。情報のヒエラルキーも平坦で、「いつ・どこで」が座席数と同じ重みになっていた。
管理画面 UI の方針（操作性・認知負荷・フィードバック優先）に沿って、隠すべきものは隠し、必要な数値を前に出す形に。

## 変更
- `src/lib/queries/events.ts`: `getEventStats(eventId)` を追加（programs / event_members(performer) / invitations / companions の集計）
- `src/app/(main)/events/[eventId]/page.tsx`: `getEventDetail` と `getEventStats` を `Promise.all` で並列取得
- `src/app/_components/event-detail.tsx`: レイアウト全面刷新

## Test plan
- [x] `pnpm type-check` / `pnpm lint` 通過
- [x] `NEXT_PUBLIC_VERCEL_ENV=preview pnpm dev` でログイン後、`/events/[id]` にアクセスし表示確認
- [x] ヒーロー（タイトル / 開演 / 会場 / 座席）と管理タイル4枚の表示・数値が出ること
- [ ] ステータス変更の折りたたみ開閉
- [ ] 編集モード切替・編集サブミット
- [ ] 削除フロー（draft / finished のとき）
- [ ] performer ロールでの表示（編集・ステータス変更・削除が出ないこと）

🤖 Generated with [Claude Code](https://claude.com/claude-code)