### PR TITLE
test(db): invitations / respond-invitation のテストを追加（issue #55 ステップ2 Step A）

### DIFF
--- a/src/lib/queries/invitations.test.ts
+++ b/src/lib/queries/invitations.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+  addCompanion,
+  addEventMember,
+  addInvitation,
+  createEvent,
+  createUser,
+} from "../../../tests/db/factories";
+import {
+  getCheckInList,
+  getCheckInSummary,
+  getConsumedSeats,
+  getInvitationByToken,
+  getInvitationsByEventId,
+  getSeatSummary,
+} from "./invitations";
+
+describe("getConsumedSeats", () => {
+  it("accepted の guest と companion を合算する。pending / declined は数えない", async () => {
+    const event = await createEvent();
+    const accepted = await addInvitation({
+      eventId: event.id,
+      status: "accepted",
+    });
+    await addCompanion({ invitationId: accepted.id });
+    await addCompanion({ invitationId: accepted.id });
+    await addInvitation({ eventId: event.id, status: "pending" });
+    const declined = await addInvitation({
+      eventId: event.id,
+      status: "declined",
+    });
+    // declined に紐づく companion はカウントされない（実運用上は削除される想定だが念のため）
+    await addCompanion({ invitationId: declined.id });
+
+    const consumed = await getConsumedSeats(event.id);
+
+    expect(consumed).toBe(1 + 2); // accepted guest + companions
+  });
+
+  it("他イベントの招待を含めない", async () => {
+    const event = await createEvent();
+    const other = await createEvent();
+    await addInvitation({ eventId: other.id, status: "accepted" });
+
+    expect(await getConsumedSeats(event.id)).toBe(0);
+  });
+});
+
+describe("getSeatSummary", () => {
+  it("totalSeats から consumed を引いた値を remaining に返す", async () => {
+    const event = await createEvent({ totalSeats: 10 });
+    await addInvitation({ eventId: event.id, status: "accepted" });
+
+    const summary = await getSeatSummary(event.id, 10);
+    expect(summary).toEqual({ totalSeats: 10, consumed: 1, remaining: 9 });
+  });
+
+  it("totalSeats が 0 のときは remaining = null（無制限扱い）", async () => {
+    const event = await createEvent({ totalSeats: 0 });
+    await addInvitation({ eventId: event.id, status: "accepted" });
+
+    const summary = await getSeatSummary(event.id, 0);
+    expect(summary).toEqual({ totalSeats: 0, consumed: 1, remaining: null });
+  });
+});
+
+describe("getCheckInSummary / getCheckInList", () => {
+  it("accepted のみ集計、guest / companion の checkedIn を分けて返す", async () => {
+    const event = await createEvent();
+    const accepted1 = await addInvitation({
+      eventId: event.id,
+      status: "accepted",
+      checkedIn: true,
+      checkedInAt: 1000,
+    });
+    await addCompanion({
+      invitationId: accepted1.id,
+      checkedIn: true,
+      checkedInAt: 1100,
+    });
+    await addCompanion({ invitationId: accepted1.id });
+    const accepted2 = await addInvitation({
+      eventId: event.id,
+      status: "accepted",
+    });
+    await addCompanion({ invitationId: accepted2.id });
+    // pending / declined は集計対象外
+    await addInvitation({ eventId: event.id, status: "pending" });
+    await addInvitation({ eventId: event.id, status: "declined" });
+
+    const summary = await getCheckInSummary(event.id);
+    expect(summary).toEqual({
+      totalAccepted: 2,
+      totalCompanions: 3,
+      checkedInGuests: 1,
+      checkedInCompanions: 1,
+    });
+
+    const list = await getCheckInList(event.id);
+    expect(list).toHaveLength(2);
+    const a1 = list.find((r) => r.id === accepted1.id);
+    expect(a1?.checkedIn).toBe(true);
+    expect(a1?.companions).toHaveLength(2);
+  });
+});
+
+describe("getInvitationByToken / getInvitationsByEventId", () => {
+  it("member 削除済みの招待は inviterDisplayName にスナップショット名 + サフィックスが入る", async () => {
+    const user = await createUser();
+    const event = await createEvent();
+    const memberId = await addEventMember({
+      eventId: event.id,
+      userId: user.id,
+      displayName: "現在の名前",
+    });
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      inviterDisplayName: "発行時の名前",
+    });
+
+    // 現在のメンバー名で表示される
+    const got1 = await getInvitationByToken(inv.token);
+    expect(got1?.inviterDisplayName).toBe("現在の名前");
+
+    // memberId を null（削除済み相当）にすると、スナップショット名 + サフィックス
+    const inv2 = await addInvitation({
+      eventId: event.id,
+      memberId: null,
+      inviterDisplayName: "削除された人",
+    });
+    const got2 = await getInvitationByToken(inv2.token);
+    expect(got2?.inviterDisplayName).toBe("削除された人（削除済み）");
+
+    const list = await getInvitationsByEventId(event.id);
+    const found = list.find((r) => r.id === inv2.id);
+    expect(found?.inviterDisplayName).toBe("削除された人（削除済み）");
+  });
+
+  it("getInvitationByToken: token が一致しなければ undefined", async () => {
+    const got = await getInvitationByToken("nonexistent-token");
+    expect(got).toBeUndefined();
+  });
+});

--- a/tests/db/actions/invitations.test.ts
+++ b/tests/db/actions/invitations.test.ts
@@ -1,0 +1,294 @@
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import {
+  createGuestInvitation,
+  deleteInvitation,
+  invalidateInvitation,
+  proxyChangeStatus,
+} from "@/app/(main)/events/[eventId]/invitations/_actions";
+import { db } from "@/db";
+import { companions, invitations } from "@/db/schema";
+import {
+  addCompanion,
+  addEventMember,
+  addInvitation,
+  createEvent,
+  createUser,
+} from "../factories";
+import { loginAs } from "../helpers/auth";
+
+async function setupOrganizer(
+  eventOverrides: {
+    totalSeats?: number;
+    status?: "draft" | "published" | "ongoing" | "finished";
+  } = {},
+) {
+  const user = await createUser();
+  const event = await createEvent({
+    status: "published",
+    totalSeats: 10,
+    ...eventOverrides,
+  });
+  const memberId = await addEventMember({
+    eventId: event.id,
+    userId: user.id,
+    role: "organizer",
+  });
+  loginAs(user);
+  return { user, event, memberId };
+}
+
+describe("createGuestInvitation", () => {
+  it("token を発行し、memberId 紐付けで invitations に INSERT する", async () => {
+    const { event, memberId } = await setupOrganizer();
+
+    const result = await createGuestInvitation(event.id, "ゲスト太郎");
+    expect(result).toEqual({ token: expect.any(String) });
+
+    const rows = await db.query.invitations.findMany({
+      where: eq(invitations.eventId, event.id),
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      memberId,
+      guestName: "ゲスト太郎",
+      status: "pending",
+    });
+  });
+
+  it("draft イベントには発行できない", async () => {
+    const { event } = await setupOrganizer({ status: "draft" });
+    const result = await createGuestInvitation(event.id);
+    expect(result).toEqual({ error: expect.any(String) });
+  });
+
+  it("非メンバーは発行不可", async () => {
+    const event = await createEvent({ status: "published" });
+    const stranger = await createUser();
+    loginAs(stranger);
+    const result = await createGuestInvitation(event.id);
+    expect(result).toEqual({ error: "権限がありません" });
+  });
+});
+
+describe("invalidateInvitation", () => {
+  it("pending → invalidatedAt のみセット、座席は変わらない", async () => {
+    const { event, memberId } = await setupOrganizer();
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "pending",
+    });
+
+    const result = await invalidateInvitation(event.id, inv.id);
+    expect(result).toBeUndefined();
+
+    const after = await db.query.invitations.findFirst({
+      where: eq(invitations.id, inv.id),
+    });
+    expect(after?.invalidatedAt).toBeTruthy();
+    expect(after?.status).toBe("pending");
+  });
+
+  it("accepted → status=declined + companions 全削除で座席が解放される", async () => {
+    const { event, memberId } = await setupOrganizer();
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+      checkedIn: true,
+      checkedInAt: 1234,
+    });
+    await addCompanion({ invitationId: inv.id });
+    await addCompanion({ invitationId: inv.id });
+
+    const result = await invalidateInvitation(event.id, inv.id);
+    expect(result).toBeUndefined();
+
+    const after = await db.query.invitations.findFirst({
+      where: eq(invitations.id, inv.id),
+    });
+    expect(after).toMatchObject({
+      status: "declined",
+      checkedIn: false,
+      checkedInAt: null,
+    });
+    expect(after?.invalidatedAt).toBeTruthy();
+
+    const remainingCompanions = await db
+      .select()
+      .from(companions)
+      .where(eq(companions.invitationId, inv.id));
+    expect(remainingCompanions).toHaveLength(0);
+  });
+
+  it("既に無効化されているとエラー", async () => {
+    const { event, memberId } = await setupOrganizer();
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "pending",
+      invalidatedAt: 1,
+    });
+    const result = await invalidateInvitation(event.id, inv.id);
+    expect(result).toEqual({ error: expect.stringContaining("無効化") });
+  });
+
+  it("出演者は他人が発行した招待を無効化できない", async () => {
+    const { event } = await setupOrganizer();
+    const performerUser = await createUser();
+    const performerMemberId = await addEventMember({
+      eventId: event.id,
+      userId: performerUser.id,
+      role: "performer",
+    });
+    const otherUser = await createUser();
+    const otherMemberId = await addEventMember({
+      eventId: event.id,
+      userId: otherUser.id,
+      role: "performer",
+    });
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId: otherMemberId,
+      status: "pending",
+    });
+    // 出演者本人としてログイン
+    loginAs(performerUser);
+    void performerMemberId;
+    const result = await invalidateInvitation(event.id, inv.id);
+    expect(result).toEqual({ error: "権限がありません" });
+  });
+});
+
+describe("proxyChangeStatus", () => {
+  it("declined → accepted: 空きあり時は成功、座席消費数が増える", async () => {
+    const { event, memberId } = await setupOrganizer({ totalSeats: 5 });
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "declined",
+    });
+
+    const result = await proxyChangeStatus(event.id, inv.id, "accepted");
+    expect(result).toBeUndefined();
+
+    const after = await db.query.invitations.findFirst({
+      where: eq(invitations.id, inv.id),
+    });
+    expect(after?.status).toBe("accepted");
+    expect(after?.respondedAt).toBeTruthy();
+  });
+
+  it("declined → accepted: 満席時はエラー", async () => {
+    const { event, memberId } = await setupOrganizer({ totalSeats: 1 });
+    // 既に満席
+    await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+    });
+    const target = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "declined",
+    });
+
+    const result = await proxyChangeStatus(event.id, target.id, "accepted");
+    expect(result).toEqual({ error: expect.stringContaining("満席") });
+
+    const after = await db.query.invitations.findFirst({
+      where: eq(invitations.id, target.id),
+    });
+    expect(after?.status).toBe("declined");
+  });
+
+  it("accepted → declined: companions 削除 + checkedIn リセット", async () => {
+    const { event, memberId } = await setupOrganizer();
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+      checkedIn: true,
+      checkedInAt: 1000,
+    });
+    await addCompanion({ invitationId: inv.id });
+
+    const result = await proxyChangeStatus(event.id, inv.id, "declined");
+    expect(result).toBeUndefined();
+
+    const after = await db.query.invitations.findFirst({
+      where: eq(invitations.id, inv.id),
+    });
+    expect(after).toMatchObject({
+      status: "declined",
+      checkedIn: false,
+      checkedInAt: null,
+    });
+    const comps = await db
+      .select()
+      .from(companions)
+      .where(eq(companions.invitationId, inv.id));
+    expect(comps).toHaveLength(0);
+  });
+
+  it("pending には適用不可", async () => {
+    const { event, memberId } = await setupOrganizer();
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "pending",
+    });
+    const result = await proxyChangeStatus(event.id, inv.id, "accepted");
+    expect(result).toEqual({ error: expect.any(String) });
+  });
+
+  it("organizer 以外は不可", async () => {
+    const { event, memberId } = await setupOrganizer();
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "declined",
+    });
+    const performer = await createUser();
+    await addEventMember({
+      eventId: event.id,
+      userId: performer.id,
+      role: "performer",
+    });
+    loginAs(performer);
+    const result = await proxyChangeStatus(event.id, inv.id, "accepted");
+    expect(result).toEqual({ error: "権限がありません" });
+  });
+});
+
+describe("deleteInvitation", () => {
+  it("invalidated のみ DELETE 可、それ以外はエラー", async () => {
+    const { event, memberId } = await setupOrganizer();
+
+    const active = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "pending",
+    });
+    const fail = await deleteInvitation(event.id, active.id);
+    expect(fail).toEqual({ error: expect.any(String) });
+    const stillThere = await db.query.invitations.findFirst({
+      where: eq(invitations.id, active.id),
+    });
+    expect(stillThere).toBeDefined();
+
+    const invalidated = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "pending",
+      invalidatedAt: 1,
+    });
+    const ok = await deleteInvitation(event.id, invalidated.id);
+    expect(ok).toBeUndefined();
+    const gone = await db.query.invitations.findFirst({
+      where: eq(invitations.id, invalidated.id),
+    });
+    expect(gone).toBeUndefined();
+  });
+});

--- a/tests/db/actions/invitations.test.ts
+++ b/tests/db/actions/invitations.test.ts
@@ -137,7 +137,7 @@ describe("invalidateInvitation", () => {
   it("出演者は他人が発行した招待を無効化できない", async () => {
     const { event } = await setupOrganizer();
     const performerUser = await createUser();
-    const performerMemberId = await addEventMember({
+    await addEventMember({
       eventId: event.id,
       userId: performerUser.id,
       role: "performer",
@@ -155,7 +155,6 @@ describe("invalidateInvitation", () => {
     });
     // 出演者本人としてログイン
     loginAs(performerUser);
-    void performerMemberId;
     const result = await invalidateInvitation(event.id, inv.id);
     expect(result).toEqual({ error: "権限がありません" });
   });

--- a/tests/db/actions/respond-invitation.test.ts
+++ b/tests/db/actions/respond-invitation.test.ts
@@ -1,0 +1,215 @@
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { respondToInvitation } from "@/app/i/[token]/_actions";
+import { db } from "@/db";
+import { companions, invitations } from "@/db/schema";
+import {
+  addCompanion,
+  addEventMember,
+  addInvitation,
+  createEvent,
+  createUser,
+} from "../factories";
+
+const baseGuestInfo = {
+  guestName: "ゲスト花子",
+  guestEmail: "guest@example.com",
+};
+
+async function setupInvitation(opts: {
+  eventStatus?: "draft" | "published" | "ongoing" | "finished";
+  totalSeats?: number;
+  invitationStatus?: "pending" | "accepted" | "declined";
+  existingCompanions?: number;
+  invalidated?: boolean;
+}) {
+  const user = await createUser();
+  const event = await createEvent({
+    status: opts.eventStatus ?? "published",
+    totalSeats: opts.totalSeats ?? 10,
+  });
+  const memberId = await addEventMember({
+    eventId: event.id,
+    userId: user.id,
+    role: "organizer",
+  });
+  const inv = await addInvitation({
+    eventId: event.id,
+    memberId,
+    status: opts.invitationStatus ?? "pending",
+    invalidatedAt: opts.invalidated ? 1 : undefined,
+  });
+  for (let i = 0; i < (opts.existingCompanions ?? 0); i++) {
+    await addCompanion({ invitationId: inv.id, name: `既存${i}` });
+  }
+  return { event, inv };
+}
+
+describe("respondToInvitation - イベントステータス制約", () => {
+  it("draft イベントは回答できない", async () => {
+    const { inv } = await setupInvitation({ eventStatus: "draft" });
+    const res = await respondToInvitation(inv.token, {
+      ...baseGuestInfo,
+      attendance: "accepted",
+      companions: [],
+    });
+    expect(res).toEqual({ error: "現在準備中です" });
+  });
+
+  it("finished イベントは回答できない", async () => {
+    const { inv } = await setupInvitation({ eventStatus: "finished" });
+    const res = await respondToInvitation(inv.token, {
+      ...baseGuestInfo,
+      attendance: "accepted",
+      companions: [],
+    });
+    expect(res).toEqual({ error: "この招待リンクは期限切れです" });
+  });
+
+  it("invalidated かつ pending: 無効と判定", async () => {
+    const { inv } = await setupInvitation({
+      eventStatus: "published",
+      invitationStatus: "pending",
+      invalidated: true,
+    });
+    const res = await respondToInvitation(inv.token, {
+      ...baseGuestInfo,
+      attendance: "accepted",
+      companions: [],
+    });
+    expect(res).toEqual({ error: "この招待リンクは無効です" });
+  });
+});
+
+describe("respondToInvitation - 受諾", () => {
+  it("pending → accepted で companions 挿入、status / 回答日時が反映される", async () => {
+    const { inv } = await setupInvitation({});
+    const res = await respondToInvitation(inv.token, {
+      ...baseGuestInfo,
+      attendance: "accepted",
+      companions: ["同伴1", "同伴2"],
+    });
+    expect(res).toBeUndefined();
+
+    const after = await db.query.invitations.findFirst({
+      where: eq(invitations.id, inv.id),
+      with: { companions: true },
+    });
+    expect(after).toMatchObject({
+      status: "accepted",
+      guestName: baseGuestInfo.guestName,
+      guestEmail: baseGuestInfo.guestEmail,
+    });
+    expect(after?.respondedAt).toBeTruthy();
+    expect(after?.companions.map((c) => c.name).sort()).toEqual([
+      "同伴1",
+      "同伴2",
+    ]);
+  });
+
+  it("満席時は受諾できない（座席チェック）", async () => {
+    const event = await createEvent({ status: "published", totalSeats: 1 });
+    const user = await createUser();
+    const memberId = await addEventMember({
+      eventId: event.id,
+      userId: user.id,
+      role: "organizer",
+    });
+    // 既に 1 席使用済み
+    await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+    });
+    const target = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "pending",
+    });
+    const res = await respondToInvitation(target.token, {
+      ...baseGuestInfo,
+      attendance: "accepted",
+      companions: [],
+    });
+    expect(res).toEqual({ error: expect.stringContaining("満席") });
+
+    const after = await db.query.invitations.findFirst({
+      where: eq(invitations.id, target.id),
+    });
+    expect(after?.status).toBe("pending");
+  });
+
+  it("accepted → 同伴者数を増やす変更: 自分の現使用席を考慮した残席計算", async () => {
+    // 3 席のイベントで自分 1 + 同伴 1 = 2 使用中。+1 同伴に増やせる（合計 3）
+    const event = await createEvent({ status: "published", totalSeats: 3 });
+    const user = await createUser();
+    const memberId = await addEventMember({
+      eventId: event.id,
+      userId: user.id,
+      role: "organizer",
+    });
+    const target = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+    });
+    await addCompanion({ invitationId: target.id, name: "旧同伴" });
+
+    const res = await respondToInvitation(target.token, {
+      ...baseGuestInfo,
+      attendance: "accepted",
+      companions: ["新同伴1", "新同伴2"],
+    });
+    expect(res).toBeUndefined();
+
+    const after = await db.query.invitations.findFirst({
+      where: eq(invitations.id, target.id),
+      with: { companions: true },
+    });
+    expect(after?.companions.map((c) => c.name).sort()).toEqual([
+      "新同伴1",
+      "新同伴2",
+    ]);
+  });
+});
+
+describe("respondToInvitation - 辞退", () => {
+  it("accepted → declined: companions 削除 + checkedIn リセット", async () => {
+    const event = await createEvent({ status: "published", totalSeats: 10 });
+    const user = await createUser();
+    const memberId = await addEventMember({
+      eventId: event.id,
+      userId: user.id,
+      role: "organizer",
+    });
+    const target = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+      checkedIn: true,
+      checkedInAt: 100,
+    });
+    await addCompanion({ invitationId: target.id });
+
+    const res = await respondToInvitation(target.token, {
+      ...baseGuestInfo,
+      attendance: "declined",
+      companions: [],
+    });
+    expect(res).toBeUndefined();
+
+    const after = await db.query.invitations.findFirst({
+      where: eq(invitations.id, target.id),
+    });
+    expect(after).toMatchObject({
+      status: "declined",
+      checkedIn: false,
+      checkedInAt: null,
+    });
+    const comps = await db
+      .select()
+      .from(companions)
+      .where(eq(companions.invitationId, target.id));
+    expect(comps).toHaveLength(0);
+  });
+});

--- a/tests/db/factories.ts
+++ b/tests/db/factories.ts
@@ -1,5 +1,16 @@
 import { db } from "@/db";
-import { eventMembers, events, type MemberRole, users } from "@/db/schema";
+import {
+  companions,
+  eventMembers,
+  events,
+  invitations,
+  type MemberRole,
+  performerInvitations,
+  programPerformers,
+  programPieces,
+  programs,
+  users,
+} from "@/db/schema";
 
 let counter = 0;
 const nextId = (prefix: string) =>
@@ -58,4 +69,108 @@ export async function addEventMember({
     displayName: displayName ?? `Member ${id}`,
   });
   return id;
+}
+
+type InvitationOverrides = Partial<typeof invitations.$inferInsert> & {
+  eventId: string;
+};
+
+export async function addInvitation(overrides: InvitationOverrides) {
+  const id = overrides.id ?? nextId("inv");
+  const row = {
+    id,
+    token: overrides.token ?? nextId("token"),
+    inviterDisplayName: overrides.inviterDisplayName ?? "主催者",
+    ...overrides,
+  } satisfies typeof invitations.$inferInsert;
+  await db.insert(invitations).values(row);
+  const created = await db.query.invitations.findFirst({
+    where: (t, { eq }) => eq(t.id, id),
+  });
+  if (!created) throw new Error("addInvitation: insert failed");
+  return created;
+}
+
+type CompanionOverrides = Partial<typeof companions.$inferInsert> & {
+  invitationId: string;
+};
+
+export async function addCompanion(overrides: CompanionOverrides) {
+  const id = overrides.id ?? nextId("comp");
+  const row = {
+    id,
+    name: overrides.name ?? `Companion ${id}`,
+    ...overrides,
+  } satisfies typeof companions.$inferInsert;
+  await db.insert(companions).values(row);
+  return row;
+}
+
+type PerformerInvitationOverrides = Partial<
+  typeof performerInvitations.$inferInsert
+> & { eventId: string };
+
+export async function addPerformerInvitation(
+  overrides: PerformerInvitationOverrides,
+) {
+  const id = overrides.id ?? nextId("perfinv");
+  const row = {
+    id,
+    token: overrides.token ?? nextId("ptoken"),
+    displayName: overrides.displayName ?? `出演者 ${id}`,
+    ...overrides,
+  } satisfies typeof performerInvitations.$inferInsert;
+  await db.insert(performerInvitations).values(row);
+  return row;
+}
+
+type ProgramOverrides = Partial<typeof programs.$inferInsert> & {
+  eventId: string;
+};
+
+export async function addProgram(overrides: ProgramOverrides) {
+  const id = overrides.id ?? nextId("prog");
+  const row = {
+    id,
+    sortOrder: overrides.sortOrder ?? 1,
+    type: overrides.type ?? "performance",
+    ...overrides,
+  } satisfies typeof programs.$inferInsert;
+  await db.insert(programs).values(row);
+  return row;
+}
+
+type ProgramPieceOverrides = Partial<typeof programPieces.$inferInsert> & {
+  programId: string;
+};
+
+export async function addProgramPiece(overrides: ProgramPieceOverrides) {
+  const id = overrides.id ?? nextId("piece");
+  const row = {
+    id,
+    sortOrder: overrides.sortOrder ?? 1,
+    title: overrides.title ?? `Piece ${id}`,
+    ...overrides,
+  } satisfies typeof programPieces.$inferInsert;
+  await db.insert(programPieces).values(row);
+  return row;
+}
+
+type ProgramPerformerOverrides = Partial<
+  typeof programPerformers.$inferInsert
+> & {
+  programId: string;
+  memberId: string;
+};
+
+export async function addProgramPerformer(
+  overrides: ProgramPerformerOverrides,
+) {
+  const id = overrides.id ?? nextId("pp");
+  const row = {
+    id,
+    ...overrides,
+  } satisfies typeof programPerformers.$inferInsert;
+  await db.insert(programPerformers).values(row);
+  return row;
 }

--- a/tests/db/helpers/auth.ts
+++ b/tests/db/helpers/auth.ts
@@ -1,0 +1,26 @@
+// Server Action テスト用の session mock helper。
+// setup.ts で vi.mock("@/lib/session") を仕込み、globalThis 経由で
+// session を切り替える。
+
+type MockUser = { id: string };
+type MockSession = {
+  user: MockUser;
+  session: { id: string };
+};
+
+function setMockSessionRaw(s: MockSession | null) {
+  (globalThis as { __mockSession?: unknown }).__mockSession = s;
+}
+
+export function loginAs(user: MockUser): MockSession {
+  const session = {
+    user: { id: user.id },
+    session: { id: `test-session-${user.id}` },
+  } satisfies MockSession;
+  setMockSessionRaw(session);
+  return session;
+}
+
+export function logout() {
+  setMockSessionRaw(null);
+}

--- a/tests/db/setup.ts
+++ b/tests/db/setup.ts
@@ -1,20 +1,66 @@
 import { mkdirSync, rmSync } from "node:fs";
-import { beforeEach } from "vitest";
+import { beforeEach, vi } from "vitest";
 
 const TEST_DB_DIR = ".test-db";
 const TEST_DB_PATH = `${TEST_DB_DIR}/test.db`;
 
-rmSync(TEST_DB_DIR, { recursive: true, force: true });
-mkdirSync(TEST_DB_DIR, { recursive: true });
+// setupFiles はテストファイルごとに再実行されるため、
+// DB 削除と migrate は worker（プロセス）単位で 1 度だけ走らせる。
+const initFlag = "__lull_test_db_initialized";
+const alreadyInitialized = (globalThis as Record<string, unknown>)[initFlag];
+
+if (!alreadyInitialized) {
+  rmSync(TEST_DB_DIR, { recursive: true, force: true });
+  mkdirSync(TEST_DB_DIR, { recursive: true });
+  (globalThis as Record<string, unknown>)[initFlag] = true;
+}
 
 process.env.TURSO_DATABASE_URL = `file:${TEST_DB_PATH}`;
 process.env.TURSO_AUTH_TOKEN = "";
 
-const { migrate } = await import("drizzle-orm/libsql/migrator");
-const { db } = await import("@/db");
-await migrate(db, { migrationsFolder: "./drizzle" });
+// Next.js / 認証ランタイムの差し替え。
+// Server Action から呼ばれる next/cache, next/navigation, @/lib/session を
+// テスト中に動かすため、最小限の no-op / 例外スロー実装に置き換える。
+vi.mock("next/cache", () => ({
+  revalidatePath: () => {},
+  revalidateTag: () => {},
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  },
+  notFound: () => {
+    throw new Error("NOT_FOUND");
+  },
+}));
+
+vi.mock("@/lib/session", () => ({
+  getSession: async () => {
+    return (globalThis as { __mockSession?: unknown }).__mockSession ?? null;
+  },
+  requireSession: async () => {
+    const s = (globalThis as { __mockSession?: unknown }).__mockSession;
+    if (!s) throw new Error("REDIRECT:/");
+    return s;
+  },
+  validateReturnTo: (v: string | string[] | undefined) => {
+    const value = Array.isArray(v) ? v[0] : v;
+    if (value?.startsWith("/") && !value.startsWith("//")) return value;
+    return "/dashboard";
+  },
+}));
+
+const migrateFlag = "__lull_test_db_migrated";
+if (!(globalThis as Record<string, unknown>)[migrateFlag]) {
+  const { migrate } = await import("drizzle-orm/libsql/migrator");
+  const { db } = await import("@/db");
+  await migrate(db, { migrationsFolder: "./drizzle" });
+  (globalThis as Record<string, unknown>)[migrateFlag] = true;
+}
 
 beforeEach(async () => {
+  (globalThis as { __mockSession?: unknown }).__mockSession = null;
   const { resetDb } = await import("./reset");
   await resetDb();
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -44,6 +44,10 @@ export default defineConfig({
           environment: "node",
           setupFiles: ["tests/db/setup.ts"],
           maxWorkers: 1,
+          // setup.ts でテスト DB を初期化するため、ファイル間で同じプロセス・
+          // 同じ DB コネクションを共有する必要がある
+          isolate: false,
+          fileParallelism: false,
         },
       },
       // Storybook テスト（ブラウザ環境）

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -48,6 +48,9 @@ export default defineConfig({
           // 同じ DB コネクションを共有する必要がある
           isolate: false,
           fileParallelism: false,
+          // vitest 4: maxWorkers が他 project と異なる場合、groupOrder も
+          // 別にする必要がある（同じだと起動時に検証エラー）
+          sequence: { groupOrder: 1 },
         },
       },
       // Storybook テスト（ブラウザ環境）


### PR DESCRIPTION
## Summary

issue #55 ステップ2「DB クエリ・Server Action のテスト整備」のうち、優先度 P0 の **座席整合性まわり（Step A）** をカバー。基盤側 (#56) で整備された `tests/db/setup.ts` + `factories.ts` + `reset.ts` の上に積む。

- **基盤拡張**: Server Action を Node 上で動かすため、setup.ts に `next/cache` / `next/navigation` / `@/lib/session` の `vi.mock` を追加。`globalThis.__mockSession` 経由で `loginAs(user)` で session を切り替えるヘルパーを用意
- **vitest config**: db project に `isolate: false` / `fileParallelism: false` を追加（setupFiles の再走で test DB が消える問題への対処）
- **factory 拡張**: invitation / companion / program / programPiece / programPerformer / performerInvitation
- **テスト追加**: queries/invitations（7） / actions/invitations（13） / actions/respond-invitation（7）= 計 27 ケース

mock 戦略は「実 DB は本物、ランタイム境界だけ最小限差し替える」方針。Drizzle / SQLite / transaction はそのまま動かし、Next.js / 認証ランタイムだけ no-op か例外スローに置き換えている。

## Test plan

- [x] `pnpm test:db` — 4 files / 30 tests passed
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] セルフチェック: `proxyChangeStatus` の満席判定 (`if (remaining < 1)`) を潰すと該当テストが赤くなることを確認 → 戻して再 green
- [ ] レビュー時、Step B 以降（チェックイン / events / programs / members）の方針も plan に沿って続行する想定

🤖 Generated with [Claude Code](https://claude.com/claude-code)