### PR TITLE
test(db): Step E members / 出演者招待 / join のテスト追加 (#55)

### DIFF
--- a/src/lib/queries/members.test.ts
+++ b/src/lib/queries/members.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import {
+  addEventMember,
+  addPerformerInvitation,
+  createEvent,
+  createUser,
+} from "../../../tests/db/factories";
+import {
+  getEventMembers,
+  getPerformerInvitationByToken,
+  getPerformerInvitations,
+} from "./members";
+
+describe("getEventMembers", () => {
+  it("該当 event の member のみを user.id 付きで返す", async () => {
+    const event = await createEvent();
+    const other = await createEvent();
+    const u1 = await createUser();
+    const u2 = await createUser();
+    const u3 = await createUser();
+    await addEventMember({
+      eventId: event.id,
+      userId: u1.id,
+      role: "organizer",
+      displayName: "主催",
+    });
+    await addEventMember({
+      eventId: event.id,
+      userId: u2.id,
+      role: "performer",
+      displayName: "出演A",
+    });
+    // 別イベントの member は混ざらない
+    await addEventMember({
+      eventId: other.id,
+      userId: u3.id,
+      role: "performer",
+    });
+
+    const members = await getEventMembers(event.id);
+
+    expect(members).toHaveLength(2);
+    const byUser = Object.fromEntries(members.map((m) => [m.user.id, m]));
+    expect(byUser[u1.id]).toMatchObject({
+      role: "organizer",
+      displayName: "主催",
+    });
+    expect(byUser[u2.id]).toMatchObject({
+      role: "performer",
+      displayName: "出演A",
+    });
+  });
+
+  it("member がいなければ空配列", async () => {
+    const event = await createEvent();
+    expect(await getEventMembers(event.id)).toEqual([]);
+  });
+});
+
+describe("getPerformerInvitations", () => {
+  it("該当 event の招待のみ返す", async () => {
+    const event = await createEvent();
+    const other = await createEvent();
+    const a = await addPerformerInvitation({
+      eventId: event.id,
+      displayName: "招待A",
+    });
+    const b = await addPerformerInvitation({
+      eventId: event.id,
+      displayName: "招待B",
+      status: "invalidated",
+    });
+    await addPerformerInvitation({
+      eventId: other.id,
+      displayName: "他イベント招待",
+    });
+
+    const list = await getPerformerInvitations(event.id);
+
+    expect(list).toHaveLength(2);
+    const ids = list.map((i) => i.id).sort();
+    expect(ids).toEqual([a.id, b.id].sort());
+  });
+});
+
+describe("getPerformerInvitationByToken", () => {
+  it("token に対応する招待と event 情報を返す", async () => {
+    const event = await createEvent({
+      name: "発表会",
+      venue: "ホール",
+      status: "published",
+    });
+    const inv = await addPerformerInvitation({
+      eventId: event.id,
+      token: "tok-abc",
+      displayName: "出演者",
+    });
+
+    const result = await getPerformerInvitationByToken("tok-abc");
+
+    expect(result).toMatchObject({
+      id: inv.id,
+      token: "tok-abc",
+      displayName: "出演者",
+      status: "pending",
+      acceptedByUserId: null,
+      event: {
+        id: event.id,
+        name: "発表会",
+        venue: "ホール",
+        status: "published",
+      },
+    });
+  });
+
+  it("該当 token がなければ undefined", async () => {
+    expect(await getPerformerInvitationByToken("missing")).toBeUndefined();
+  });
+});

--- a/tests/db/actions/join.test.ts
+++ b/tests/db/actions/join.test.ts
@@ -12,11 +12,11 @@ import {
 import { loginAs, logout } from "../helpers/auth";
 
 describe("acceptPerformerInvitation", () => {
-  it("未ログインなら /join/<token> へリダイレクト", async () => {
+  it("未ログインなら returnTo 付きでログインページへリダイレクト", async () => {
     logout();
     await expect(
-      acceptPerformerInvitation("any-token", "出演者"),
-    ).rejects.toThrow("REDIRECT:/");
+      acceptPerformerInvitation("tok-xyz", "出演者"),
+    ).rejects.toThrow("REDIRECT:/?returnTo=%2Fjoin%2Ftok-xyz");
   });
 
   it("displayName が空ならエラー", async () => {

--- a/tests/db/actions/join.test.ts
+++ b/tests/db/actions/join.test.ts
@@ -1,0 +1,173 @@
+import { and, eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { acceptPerformerInvitation } from "@/app/join/[token]/_actions";
+import { db } from "@/db";
+import { eventMembers, performerInvitations } from "@/db/schema";
+import {
+  addEventMember,
+  addPerformerInvitation,
+  createEvent,
+  createUser,
+} from "../factories";
+import { loginAs, logout } from "../helpers/auth";
+
+describe("acceptPerformerInvitation", () => {
+  it("未ログインなら /join/<token> へリダイレクト", async () => {
+    logout();
+    await expect(
+      acceptPerformerInvitation("any-token", "出演者"),
+    ).rejects.toThrow("REDIRECT:/");
+  });
+
+  it("displayName が空ならエラー", async () => {
+    const user = await createUser();
+    loginAs(user);
+    const result = await acceptPerformerInvitation("any-token", "  ");
+    expect(result).toMatchObject({
+      error: expect.stringContaining("表示名"),
+    });
+  });
+
+  it("該当 token が存在しない", async () => {
+    const user = await createUser();
+    loginAs(user);
+    const result = await acceptPerformerInvitation("missing-token", "出演者");
+    expect(result).toMatchObject({ error: "この招待リンクは無効です" });
+  });
+
+  it("invalidated 招待は受諾不可", async () => {
+    const user = await createUser();
+    loginAs(user);
+    const event = await createEvent({ status: "published" });
+    const inv = await addPerformerInvitation({
+      eventId: event.id,
+      token: "tok-invalid",
+      status: "invalidated",
+    });
+
+    const result = await acceptPerformerInvitation(inv.token, "出演者");
+    expect(result).toMatchObject({ error: "この招待リンクは無効です" });
+  });
+
+  it("finished イベントは受諾不可", async () => {
+    const user = await createUser();
+    loginAs(user);
+    const event = await createEvent({ status: "finished" });
+    const inv = await addPerformerInvitation({
+      eventId: event.id,
+      token: "tok-finished",
+      status: "pending",
+    });
+
+    const result = await acceptPerformerInvitation(inv.token, "出演者");
+    expect(result).toMatchObject({ error: "この招待リンクは期限切れです" });
+  });
+
+  it("draft イベントでも新規受諾できる: eventMembers INSERT + status=accepted", async () => {
+    const user = await createUser();
+    loginAs(user);
+    const event = await createEvent({ status: "draft" });
+    const inv = await addPerformerInvitation({
+      eventId: event.id,
+      token: "tok-draft",
+      status: "pending",
+      displayName: "招待時の名前",
+    });
+
+    await expect(
+      acceptPerformerInvitation(inv.token, "本人入力名"),
+    ).rejects.toThrow(`REDIRECT:/events/${event.id}`);
+
+    const member = await db.query.eventMembers.findFirst({
+      where: and(
+        eq(eventMembers.eventId, event.id),
+        eq(eventMembers.userId, user.id),
+      ),
+    });
+    expect(member).toMatchObject({
+      role: "performer",
+      displayName: "本人入力名",
+    });
+
+    const after = await db.query.performerInvitations.findFirst({
+      where: eq(performerInvitations.id, inv.id),
+    });
+    expect(after).toMatchObject({
+      status: "accepted",
+      acceptedByUserId: user.id,
+    });
+    expect(after?.acceptedAt).toEqual(expect.any(Number));
+  });
+
+  it("既存 member の場合は INSERT せず redirect する", async () => {
+    const user = await createUser();
+    loginAs(user);
+    const event = await createEvent({ status: "published" });
+    // 既にメンバー（別経路で登録済み）
+    await addEventMember({
+      eventId: event.id,
+      userId: user.id,
+      role: "organizer",
+      displayName: "もとの名前",
+    });
+    const inv = await addPerformerInvitation({
+      eventId: event.id,
+      token: "tok-already-member",
+      status: "pending",
+    });
+
+    await expect(
+      acceptPerformerInvitation(inv.token, "新名前"),
+    ).rejects.toThrow(`REDIRECT:/events/${event.id}`);
+
+    // event_members は変更されない（INSERT されない、displayName も変わらない）
+    const members = await db.query.eventMembers.findMany({
+      where: and(
+        eq(eventMembers.eventId, event.id),
+        eq(eventMembers.userId, user.id),
+      ),
+    });
+    expect(members).toHaveLength(1);
+    expect(members[0]?.displayName).toBe("もとの名前");
+
+    // 招待は pending のまま（受諾フローを通っていない）
+    const after = await db.query.performerInvitations.findFirst({
+      where: eq(performerInvitations.id, inv.id),
+    });
+    expect(after?.status).toBe("pending");
+  });
+
+  it("本人が既に accepted 済みの場合は redirect", async () => {
+    const user = await createUser();
+    loginAs(user);
+    const event = await createEvent({ status: "published" });
+    const inv = await addPerformerInvitation({
+      eventId: event.id,
+      token: "tok-self-accepted",
+      status: "accepted",
+      acceptedByUserId: user.id,
+    });
+
+    await expect(
+      acceptPerformerInvitation(inv.token, "出演者"),
+    ).rejects.toThrow(`REDIRECT:/events/${event.id}`);
+  });
+
+  it("別人が既に accepted した招待はエラー", async () => {
+    const me = await createUser();
+    const other = await createUser();
+    loginAs(me);
+    const event = await createEvent({ status: "published" });
+    const inv = await addPerformerInvitation({
+      eventId: event.id,
+      token: "tok-other-accepted",
+      status: "accepted",
+      acceptedByUserId: other.id,
+    });
+
+    const result = await acceptPerformerInvitation(inv.token, "出演者");
+    expect(result).toMatchObject({
+      error: "この招待リンクは既に使用済みです",
+    });
+  });
+});

--- a/tests/db/actions/members.test.ts
+++ b/tests/db/actions/members.test.ts
@@ -1,0 +1,350 @@
+import { and, eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import {
+  createPerformerInvitation,
+  deletePerformerInvitation,
+  invalidatePerformerInvitation,
+  removeMember,
+  updateDisplayName,
+} from "@/app/(main)/events/[eventId]/members/_actions";
+import { db } from "@/db";
+import {
+  type EventStatus,
+  eventMembers,
+  performerInvitations,
+} from "@/db/schema";
+import {
+  addEventMember,
+  addPerformerInvitation,
+  addProgram,
+  addProgramPerformer,
+  createEvent,
+  createUser,
+} from "../factories";
+import { loginAs } from "../helpers/auth";
+
+async function setupOrganizer(eventOverrides: { status?: EventStatus } = {}) {
+  const user = await createUser();
+  const event = await createEvent({
+    status: eventOverrides.status ?? "published",
+  });
+  const memberId = await addEventMember({
+    eventId: event.id,
+    userId: user.id,
+    role: "organizer",
+    displayName: "主催者",
+  });
+  loginAs(user);
+  return { user, event, memberId };
+}
+
+function fd(displayName: string) {
+  const f = new FormData();
+  f.set("displayName", displayName);
+  return f;
+}
+
+describe("createPerformerInvitation", () => {
+  it("token 付きで performer_invitations に INSERT する", async () => {
+    const { event } = await setupOrganizer();
+
+    const result = await createPerformerInvitation(
+      event.id,
+      null,
+      fd("出演者A"),
+    );
+
+    expect(result).toEqual({ token: expect.any(String) });
+    const rows = await db.query.performerInvitations.findMany({
+      where: eq(performerInvitations.eventId, event.id),
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      displayName: "出演者A",
+      status: "pending",
+      acceptedByUserId: null,
+    });
+    expect(rows[0]?.token).toEqual(expect.any(String));
+  });
+
+  it("非主催者は発行不可", async () => {
+    const { event } = await setupOrganizer();
+    const stranger = await createUser();
+    loginAs(stranger);
+
+    const result = await createPerformerInvitation(
+      event.id,
+      null,
+      fd("出演者"),
+    );
+    expect(result).toMatchObject({ error: "権限がありません" });
+  });
+
+  it("ongoing イベントでは発行できない", async () => {
+    const { event } = await setupOrganizer({ status: "ongoing" });
+    const result = await createPerformerInvitation(
+      event.id,
+      null,
+      fd("出演者"),
+    );
+    expect(result).toMatchObject({
+      error: expect.stringContaining("発行できません"),
+    });
+  });
+
+  it("displayName が空ならバリデーションエラー", async () => {
+    const { event } = await setupOrganizer();
+    const result = await createPerformerInvitation(event.id, null, fd("  "));
+    expect(result).toMatchObject({
+      error: expect.stringContaining("表示名"),
+      fields: { displayName: "  " },
+    });
+  });
+});
+
+describe("updateDisplayName", () => {
+  it("自分の event_members.displayName のみ更新する", async () => {
+    const { user, event } = await setupOrganizer();
+    // 別ユーザーの member も置く
+    const other = await createUser();
+    const otherMemberId = await addEventMember({
+      eventId: event.id,
+      userId: other.id,
+      role: "performer",
+      displayName: "他人",
+    });
+
+    const result = await updateDisplayName(event.id, null, fd("新しい名前"));
+    expect(result).toBeNull();
+
+    const me = await db.query.eventMembers.findFirst({
+      where: and(
+        eq(eventMembers.eventId, event.id),
+        eq(eventMembers.userId, user.id),
+      ),
+    });
+    expect(me?.displayName).toBe("新しい名前");
+
+    const others = await db.query.eventMembers.findFirst({
+      where: eq(eventMembers.id, otherMemberId),
+    });
+    expect(others?.displayName).toBe("他人");
+  });
+
+  it("自分が member でない場合はエラー", async () => {
+    const event = await createEvent({ status: "published" });
+    const stranger = await createUser();
+    loginAs(stranger);
+
+    const result = await updateDisplayName(event.id, null, fd("名前"));
+    expect(result).toMatchObject({ error: "メンバーが見つかりません" });
+  });
+
+  it("finished イベントでは変更できない", async () => {
+    const { event } = await setupOrganizer({ status: "finished" });
+    const result = await updateDisplayName(event.id, null, fd("名前"));
+    expect(result).toMatchObject({
+      error: expect.stringContaining("変更できません"),
+    });
+  });
+});
+
+describe("removeMember", () => {
+  it("組織者は削除不可", async () => {
+    const { event, memberId } = await setupOrganizer();
+    const result = await removeMember(event.id, memberId);
+    expect(result).toMatchObject({ error: "主催者は削除できません" });
+  });
+
+  it("programPerformers に紐づいた member は削除不可", async () => {
+    const { event } = await setupOrganizer();
+    const target = await createUser();
+    const targetMemberId = await addEventMember({
+      eventId: event.id,
+      userId: target.id,
+      role: "performer",
+    });
+    const program = await addProgram({ eventId: event.id });
+    await addProgramPerformer({
+      programId: program.id,
+      memberId: targetMemberId,
+    });
+
+    const result = await removeMember(event.id, targetMemberId);
+    expect(result).toMatchObject({
+      error: expect.stringContaining("プログラム"),
+    });
+
+    const still = await db.query.eventMembers.findFirst({
+      where: eq(eventMembers.id, targetMemberId),
+    });
+    expect(still).toBeDefined();
+  });
+
+  it("通常の performer 削除で eventMembers と該当 acceptedInvitation を連鎖削除する", async () => {
+    const { event } = await setupOrganizer();
+    const target = await createUser();
+    const targetMemberId = await addEventMember({
+      eventId: event.id,
+      userId: target.id,
+      role: "performer",
+    });
+    // 受諾済みの招待
+    const acceptedInv = await addPerformerInvitation({
+      eventId: event.id,
+      status: "accepted",
+      acceptedByUserId: target.id,
+    });
+    // 別人の招待は残るはず
+    const otherInv = await addPerformerInvitation({
+      eventId: event.id,
+      status: "pending",
+    });
+
+    const result = await removeMember(event.id, targetMemberId);
+    expect(result).toBeUndefined();
+
+    const member = await db.query.eventMembers.findFirst({
+      where: eq(eventMembers.id, targetMemberId),
+    });
+    expect(member).toBeUndefined();
+
+    const accepted = await db.query.performerInvitations.findFirst({
+      where: eq(performerInvitations.id, acceptedInv.id),
+    });
+    expect(accepted).toBeUndefined();
+
+    const survivor = await db.query.performerInvitations.findFirst({
+      where: eq(performerInvitations.id, otherInv.id),
+    });
+    expect(survivor).toBeDefined();
+  });
+
+  it("非主催者は削除不可", async () => {
+    const { event } = await setupOrganizer();
+    const target = await createUser();
+    const targetMemberId = await addEventMember({
+      eventId: event.id,
+      userId: target.id,
+      role: "performer",
+    });
+    const stranger = await createUser();
+    loginAs(stranger);
+
+    const result = await removeMember(event.id, targetMemberId);
+    expect(result).toMatchObject({ error: "権限がありません" });
+  });
+
+  it("finished イベントでは削除不可", async () => {
+    const { event } = await setupOrganizer({ status: "finished" });
+    const target = await createUser();
+    const targetMemberId = await addEventMember({
+      eventId: event.id,
+      userId: target.id,
+      role: "performer",
+    });
+    const result = await removeMember(event.id, targetMemberId);
+    expect(result).toMatchObject({
+      error: expect.stringContaining("削除できません"),
+    });
+  });
+});
+
+describe("invalidatePerformerInvitation", () => {
+  it("pending → invalidated に変える", async () => {
+    const { event } = await setupOrganizer();
+    const inv = await addPerformerInvitation({
+      eventId: event.id,
+      status: "pending",
+    });
+
+    const result = await invalidatePerformerInvitation(event.id, inv.id);
+    expect(result).toBeUndefined();
+
+    const after = await db.query.performerInvitations.findFirst({
+      where: eq(performerInvitations.id, inv.id),
+    });
+    expect(after?.status).toBe("invalidated");
+  });
+
+  it("accepted は無効化できない", async () => {
+    const { event } = await setupOrganizer();
+    const accepter = await createUser();
+    const inv = await addPerformerInvitation({
+      eventId: event.id,
+      status: "accepted",
+      acceptedByUserId: accepter.id,
+    });
+    const result = await invalidatePerformerInvitation(event.id, inv.id);
+    expect(result).toMatchObject({
+      error: expect.stringContaining("無効化"),
+    });
+
+    const after = await db.query.performerInvitations.findFirst({
+      where: eq(performerInvitations.id, inv.id),
+    });
+    expect(after?.status).toBe("accepted");
+  });
+
+  it("非主催者は無効化不可", async () => {
+    const { event } = await setupOrganizer();
+    const inv = await addPerformerInvitation({
+      eventId: event.id,
+      status: "pending",
+    });
+    const stranger = await createUser();
+    loginAs(stranger);
+
+    const result = await invalidatePerformerInvitation(event.id, inv.id);
+    expect(result).toMatchObject({ error: "権限がありません" });
+  });
+});
+
+describe("deletePerformerInvitation", () => {
+  it("invalidated 招待のみ削除できる", async () => {
+    const { event } = await setupOrganizer();
+    const inv = await addPerformerInvitation({
+      eventId: event.id,
+      status: "invalidated",
+    });
+
+    const result = await deletePerformerInvitation(event.id, inv.id);
+    expect(result).toBeUndefined();
+
+    const after = await db.query.performerInvitations.findFirst({
+      where: eq(performerInvitations.id, inv.id),
+    });
+    expect(after).toBeUndefined();
+  });
+
+  it("pending は削除できない", async () => {
+    const { event } = await setupOrganizer();
+    const inv = await addPerformerInvitation({
+      eventId: event.id,
+      status: "pending",
+    });
+    const result = await deletePerformerInvitation(event.id, inv.id);
+    expect(result).toMatchObject({
+      error: expect.stringContaining("無効化済み"),
+    });
+
+    const still = await db.query.performerInvitations.findFirst({
+      where: eq(performerInvitations.id, inv.id),
+    });
+    expect(still).toBeDefined();
+  });
+
+  it("accepted は削除できない", async () => {
+    const { event } = await setupOrganizer();
+    const accepter = await createUser();
+    const inv = await addPerformerInvitation({
+      eventId: event.id,
+      status: "accepted",
+      acceptedByUserId: accepter.id,
+    });
+    const result = await deletePerformerInvitation(event.id, inv.id);
+    expect(result).toMatchObject({
+      error: expect.stringContaining("無効化済み"),
+    });
+  });
+});

--- a/tests/db/setup.ts
+++ b/tests/db/setup.ts
@@ -39,9 +39,14 @@ vi.mock("@/lib/session", () => ({
   getSession: async () => {
     return (globalThis as { __mockSession?: unknown }).__mockSession ?? null;
   },
-  requireSession: async () => {
+  requireSession: async (returnTo?: string) => {
     const s = (globalThis as { __mockSession?: unknown }).__mockSession;
-    if (!s) throw new Error("REDIRECT:/");
+    if (!s) {
+      const target = returnTo
+        ? `/?returnTo=${encodeURIComponent(returnTo)}`
+        : "/";
+      throw new Error(`REDIRECT:${target}`);
+    }
     return s;
   },
   validateReturnTo: (v: string | string[] | undefined) => {


### PR DESCRIPTION
## Summary

issue #55 ステップ2 の **Step E**（members / 出演者招待 / join）のテストを追加します。基盤と Step A は main にマージ済み。

- **E-1** `src/lib/queries/members.test.ts` — `getEventMembers` / `getPerformerInvitations` / `getPerformerInvitationByToken` の event 絞り込み・user.id 含み・token 検索
- **E-2** `tests/db/actions/members.test.ts` — `createPerformerInvitation` / `updateDisplayName` / `removeMember` / `invalidate` / `delete` の権限・状態遷移、主催者削除不可・programPerformers 参照中保護・受諾済み招待の連鎖削除
- **E-3** `tests/db/actions/join.test.ts` — `acceptPerformerInvitation` の新規受諾、既存 member redirect、本人/別人 accepted 分岐、draft 受諾可

## Test plan

- [x] `pnpm test:db` — 7 files / 62 tests pass
- [x] `pnpm lint` — pass
- [x] `pnpm type-check` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)