### PR TITLE
test(db/step-c): events ライフサイクルと集計クエリのテスト追加

### DIFF
--- a/src/lib/queries/events.test.ts
+++ b/src/lib/queries/events.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
+  addCompanion,
   addEventMember,
+  addInvitation,
+  addProgram,
   createEvent,
   createUser,
 } from "../../../tests/db/factories";
-import { getEventsByUserId } from "./events";
+import { getEventDetail, getEventStats, getEventsByUserId } from "./events";
 
 describe("getEventsByUserId", () => {
   it("ユーザーが関わるイベントを role 付きで返す", async () => {
@@ -76,5 +79,141 @@ describe("getEventsByUserId", () => {
     const result = await getEventsByUserId(user.id);
 
     expect(result).toHaveLength(0);
+  });
+});
+
+describe("getEventDetail", () => {
+  it("id 一致のイベントのみを返す", async () => {
+    const target = await createEvent({ name: "対象" });
+    await createEvent({ name: "別" });
+
+    const result = await getEventDetail(target.id);
+
+    expect(result?.id).toBe(target.id);
+    expect(result?.name).toBe("対象");
+  });
+
+  it("存在しない id では undefined", async () => {
+    const result = await getEventDetail("not-exist");
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("getEventStats", () => {
+  it("programs / performers / invitations 分布 / checkedIn を集計する", async () => {
+    const event = await createEvent({ totalSeats: 50 });
+    const inviter = await createUser();
+    const memberId = await addEventMember({
+      eventId: event.id,
+      userId: inviter.id,
+      role: "organizer",
+    });
+
+    // performer 2名
+    const p1 = await createUser();
+    const p2 = await createUser();
+    await addEventMember({
+      eventId: event.id,
+      userId: p1.id,
+      role: "performer",
+    });
+    await addEventMember({
+      eventId: event.id,
+      userId: p2.id,
+      role: "performer",
+    });
+
+    // programs 3 件
+    await addProgram({ eventId: event.id, sortOrder: 1 });
+    await addProgram({ eventId: event.id, sortOrder: 2, type: "intermission" });
+    await addProgram({ eventId: event.id, sortOrder: 3 });
+
+    // invitations: accepted x2 (片方は checkedIn)、pending x1、declined x1、
+    // 無効化済 x1（集計から除外される）
+    const accepted1 = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+      checkedIn: true,
+      checkedInAt: 1000,
+    });
+    await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+    });
+    await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "pending",
+    });
+    await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "declined",
+    });
+    await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+      invalidatedAt: 1,
+    });
+
+    // companions: checkedIn 2 / 未 1（accepted 招待に紐づくもののみ集計）
+    await addCompanion({ invitationId: accepted1.id, checkedIn: true });
+    await addCompanion({ invitationId: accepted1.id, checkedIn: true });
+    await addCompanion({ invitationId: accepted1.id });
+
+    const stats = await getEventStats(event.id);
+
+    expect(stats).toEqual({
+      programCount: 3,
+      performerCount: 2,
+      invitationTotal: 4,
+      invitationAccepted: 2,
+      invitationPending: 1,
+      invitationDeclined: 1,
+      checkedInGuests: 1,
+      checkedInCompanions: 2,
+      totalAttendees: 3,
+    });
+  });
+
+  it("無効化済の招待に紐づく companions は checkedIn 集計対象外", async () => {
+    const event = await createEvent();
+    const inviter = await createUser();
+    const memberId = await addEventMember({
+      eventId: event.id,
+      userId: inviter.id,
+      role: "organizer",
+    });
+
+    const invalidated = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+      invalidatedAt: 1,
+    });
+    await addCompanion({ invitationId: invalidated.id, checkedIn: true });
+
+    const stats = await getEventStats(event.id);
+    expect(stats.checkedInCompanions).toBe(0);
+    expect(stats.invitationTotal).toBe(0);
+  });
+
+  it("空イベントは全て 0", async () => {
+    const event = await createEvent();
+    const stats = await getEventStats(event.id);
+    expect(stats).toEqual({
+      programCount: 0,
+      performerCount: 0,
+      invitationTotal: 0,
+      invitationAccepted: 0,
+      invitationPending: 0,
+      invitationDeclined: 0,
+      checkedInGuests: 0,
+      checkedInCompanions: 0,
+      totalAttendees: 0,
+    });
   });
 });

--- a/tests/db/actions/events.test.ts
+++ b/tests/db/actions/events.test.ts
@@ -1,0 +1,375 @@
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createEvent as createEventAction,
+  deleteEvent,
+  updateEvent,
+  updateEventStatus,
+} from "@/app/(main)/events/_actions";
+import { db } from "@/db";
+import { type EventStatus, eventMembers, events } from "@/db/schema";
+import {
+  addCompanion,
+  addEventMember,
+  addInvitation,
+  createEvent,
+  createUser,
+} from "../factories";
+import { loginAs } from "../helpers/auth";
+
+function buildCreateForm(overrides: Partial<Record<string, string>> = {}) {
+  const fd = new FormData();
+  const base: Record<string, string> = {
+    name: "テスト発表会",
+    date: "2030-05-01",
+    startTime: "13:00",
+    openTime: "12:30",
+    venue: "ホールA",
+    totalSeats: "100",
+  };
+  for (const [k, v] of Object.entries({ ...base, ...overrides })) {
+    if (v !== undefined) fd.set(k, v);
+  }
+  return fd;
+}
+
+describe("createEvent", () => {
+  beforeEach(() => {
+    // 2030-04-26 12:00 JST (= 03:00 UTC) を「現在」として固定
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2030-04-26T03:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("events INSERT + organizer eventMembers INSERT し、詳細へ redirect", async () => {
+    const user = await createUser({ name: "主催者" });
+    loginAs(user);
+
+    await expect(createEventAction(null, buildCreateForm())).rejects.toThrow(
+      /^REDIRECT:\/events\//,
+    );
+
+    const all = await db.select().from(events);
+    expect(all).toHaveLength(1);
+    expect(all[0]).toMatchObject({
+      name: "テスト発表会",
+      venue: "ホールA",
+      startDatetime: "2030-05-01T13:00",
+      openDatetime: "2030-05-01T12:30",
+      totalSeats: 100,
+      status: "draft",
+    });
+
+    const members = await db
+      .select()
+      .from(eventMembers)
+      .where(eq(eventMembers.eventId, all[0].id));
+    expect(members).toHaveLength(1);
+    expect(members[0]).toMatchObject({
+      userId: user.id,
+      role: "organizer",
+      displayName: "主催者",
+    });
+  });
+
+  it("JST 当日は登録可", async () => {
+    // 2030-04-26 が JST today なので、その日付なら成功する
+    const user = await createUser();
+    loginAs(user);
+
+    await expect(
+      createEventAction(null, buildCreateForm({ date: "2030-04-26" })),
+    ).rejects.toThrow(/^REDIRECT:/);
+  });
+
+  it("JST 過去日はエラー", async () => {
+    const user = await createUser();
+    loginAs(user);
+
+    const result = await createEventAction(
+      null,
+      buildCreateForm({ date: "2030-04-25" }),
+    );
+    expect(result).toMatchObject({
+      error: expect.stringContaining("当日以降"),
+    });
+    const all = await db.select().from(events);
+    expect(all).toHaveLength(0);
+  });
+
+  it("UTC では前日でも JST では当日扱いになる境界", async () => {
+    // 2030-04-26T15:00Z = 2030-04-27T00:00 JST
+    vi.setSystemTime(new Date("2030-04-26T15:00:00Z"));
+    const user = await createUser();
+    loginAs(user);
+
+    // JST 4/27 が today なので、4/26 は NG
+    const ng = await createEventAction(
+      null,
+      buildCreateForm({ date: "2030-04-26" }),
+    );
+    expect(ng).toMatchObject({ error: expect.stringContaining("当日以降") });
+
+    // 4/27 は OK
+    await expect(
+      createEventAction(null, buildCreateForm({ date: "2030-04-27" })),
+    ).rejects.toThrow(/^REDIRECT:/);
+  });
+
+  it("openTime が startTime より後だとエラー", async () => {
+    const user = await createUser();
+    loginAs(user);
+
+    const result = await createEventAction(
+      null,
+      buildCreateForm({ startTime: "13:00", openTime: "14:00" }),
+    );
+    expect(result).toMatchObject({ error: expect.stringContaining("開場") });
+  });
+});
+
+describe("updateEvent", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2030-04-26T03:00:00Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  async function setupOrganizer(
+    eventOverrides: Partial<{
+      status: EventStatus;
+      totalSeats: number;
+      startDatetime: string;
+      openDatetime: string | null;
+    }> = {},
+  ) {
+    const user = await createUser();
+    const event = await createEvent({
+      status: "published",
+      totalSeats: 10,
+      startDatetime: "2030-05-01T13:00",
+      openDatetime: "2030-05-01T12:30",
+      ...eventOverrides,
+    });
+    const memberId = await addEventMember({
+      eventId: event.id,
+      userId: user.id,
+      role: "organizer",
+    });
+    loginAs(user);
+    return { user, event, memberId };
+  }
+
+  function buildUpdateForm(overrides: Record<string, string> = {}) {
+    const fd = new FormData();
+    for (const [k, v] of Object.entries(overrides)) {
+      fd.set(k, v);
+    }
+    return fd;
+  }
+
+  it("通常更新が反映される", async () => {
+    const { event } = await setupOrganizer();
+    const result = await updateEvent(
+      event.id,
+      null,
+      buildUpdateForm({ name: "改名後", venue: "ホールB" }),
+    );
+    expect(result).toMatchObject({ event: expect.any(Object) });
+    const after = await db.query.events.findFirst({
+      where: eq(events.id, event.id),
+    });
+    expect(after).toMatchObject({ name: "改名後", venue: "ホールB" });
+  });
+
+  it("totalSeats を現使用席数より下にするとエラー（getConsumedSeats 連動）", async () => {
+    const { event, memberId } = await setupOrganizer({ totalSeats: 10 });
+    // accepted invitation 1 + companion 2 → consumed = 3
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+    });
+    await addCompanion({ invitationId: inv.id });
+    await addCompanion({ invitationId: inv.id });
+
+    const ng = await updateEvent(
+      event.id,
+      null,
+      buildUpdateForm({ totalSeats: "2" }),
+    );
+    expect(ng).toMatchObject({ error: expect.stringContaining("3名") });
+
+    // 3 にはできる
+    const ok = await updateEvent(
+      event.id,
+      null,
+      buildUpdateForm({ totalSeats: "3" }),
+    );
+    expect(ok).toMatchObject({ event: expect.any(Object) });
+  });
+
+  it("totalSeats=0（自由席）は consumed チェックを通る", async () => {
+    const { event, memberId } = await setupOrganizer({ totalSeats: 10 });
+    await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+    });
+
+    const ok = await updateEvent(
+      event.id,
+      null,
+      buildUpdateForm({ totalSeats: "0" }),
+    );
+    expect(ok).toMatchObject({ event: expect.any(Object) });
+    const after = await db.query.events.findFirst({
+      where: eq(events.id, event.id),
+    });
+    expect(after?.totalSeats).toBe(0);
+  });
+
+  it("ongoing / finished は編集不可", async () => {
+    const { event } = await setupOrganizer({ status: "ongoing" });
+    const ng = await updateEvent(
+      event.id,
+      null,
+      buildUpdateForm({ name: "x" }),
+    );
+    expect(ng).toMatchObject({ error: expect.any(String) });
+  });
+
+  it("非 organizer は権限なし", async () => {
+    const { event } = await setupOrganizer();
+    const stranger = await createUser();
+    loginAs(stranger);
+    const ng = await updateEvent(
+      event.id,
+      null,
+      buildUpdateForm({ name: "x" }),
+    );
+    expect(ng).toEqual({ error: "権限がありません" });
+  });
+});
+
+describe("deleteEvent", () => {
+  it("draft は削除可（redirect）", async () => {
+    const user = await createUser();
+    const event = await createEvent({ status: "draft" });
+    await addEventMember({
+      eventId: event.id,
+      userId: user.id,
+      role: "organizer",
+    });
+    loginAs(user);
+
+    await expect(deleteEvent(event.id)).rejects.toThrow("REDIRECT:/dashboard");
+    const remaining = await db.query.events.findFirst({
+      where: eq(events.id, event.id),
+    });
+    expect(remaining).toBeUndefined();
+  });
+
+  it("finished は削除可", async () => {
+    const user = await createUser();
+    const event = await createEvent({ status: "finished" });
+    await addEventMember({
+      eventId: event.id,
+      userId: user.id,
+      role: "organizer",
+    });
+    loginAs(user);
+
+    await expect(deleteEvent(event.id)).rejects.toThrow("REDIRECT:/dashboard");
+  });
+
+  it("published / ongoing は削除不可", async () => {
+    const user = await createUser();
+    loginAs(user);
+    for (const status of ["published", "ongoing"] as const) {
+      const event = await createEvent({ status });
+      await addEventMember({
+        eventId: event.id,
+        userId: user.id,
+        role: "organizer",
+      });
+      const ng = await deleteEvent(event.id);
+      expect(ng).toMatchObject({ error: expect.any(String) });
+      const still = await db.query.events.findFirst({
+        where: eq(events.id, event.id),
+      });
+      expect(still).toBeDefined();
+    }
+  });
+
+  it("非 organizer は権限なし", async () => {
+    const event = await createEvent({ status: "draft" });
+    const stranger = await createUser();
+    loginAs(stranger);
+    const result = await deleteEvent(event.id);
+    expect(result).toEqual({ error: "権限がありません" });
+  });
+});
+
+describe("updateEventStatus", () => {
+  async function setupAs(status: EventStatus) {
+    const user = await createUser();
+    const event = await createEvent({ status });
+    await addEventMember({
+      eventId: event.id,
+      userId: user.id,
+      role: "organizer",
+    });
+    loginAs(user);
+    return event;
+  }
+
+  // 期待する遷移マップは src/db/schema.ts と独立して定義する。
+  // ここを VALID_TRANSITIONS から導出すると、定数を壊しても両方が同時に
+  // 動いてしまい sanity check にならない。
+  const expectedAllowed: Record<EventStatus, readonly EventStatus[]> = {
+    draft: ["published"],
+    published: ["draft", "ongoing"],
+    ongoing: ["finished"],
+    finished: [],
+  };
+  const allStatuses: EventStatus[] = [
+    "draft",
+    "published",
+    "ongoing",
+    "finished",
+  ];
+
+  for (const from of allStatuses) {
+    for (const to of allStatuses) {
+      const allowed = expectedAllowed[from].includes(to);
+      it(`${from} → ${to} は ${allowed ? "成功" : "拒否"}`, async () => {
+        const event = await setupAs(from);
+        const result = await updateEventStatus(event.id, to);
+        const after = await db.query.events.findFirst({
+          where: eq(events.id, event.id),
+        });
+        if (allowed) {
+          expect(result).toMatchObject({ event: expect.any(Object) });
+          expect(after?.status).toBe(to);
+        } else {
+          expect(result).toMatchObject({ error: expect.any(String) });
+          expect(after?.status).toBe(from);
+        }
+      });
+    }
+  }
+
+  it("非 organizer は権限なし", async () => {
+    const event = await createEvent({ status: "draft" });
+    const stranger = await createUser();
+    loginAs(stranger);
+    const result = await updateEventStatus(event.id, "published");
+    expect(result).toEqual({ error: "権限がありません" });
+  });
+});

--- a/tests/db/helpers/auth.ts
+++ b/tests/db/helpers/auth.ts
@@ -4,7 +4,7 @@
 
 type MockUser = { id: string; name?: string | null };
 type MockSession = {
-  user: { id: string; name?: string | null };
+  user: MockUser;
   session: { id: string };
 };
 

--- a/tests/db/helpers/auth.ts
+++ b/tests/db/helpers/auth.ts
@@ -2,9 +2,9 @@
 // setup.ts で vi.mock("@/lib/session") を仕込み、globalThis 経由で
 // session を切り替える。
 
-type MockUser = { id: string };
+type MockUser = { id: string; name?: string | null };
 type MockSession = {
-  user: MockUser;
+  user: { id: string; name?: string | null };
   session: { id: string };
 };
 
@@ -14,7 +14,7 @@ function setMockSessionRaw(s: MockSession | null) {
 
 export function loginAs(user: MockUser): MockSession {
   const session = {
-    user: { id: user.id },
+    user: { id: user.id, name: user.name ?? null },
     session: { id: `test-session-${user.id}` },
   } satisfies MockSession;
   setMockSessionRaw(session);


### PR DESCRIPTION
## Summary

issue #55 ステップ2 / Step C（events ライフサイクル）。

- **C-1** `src/lib/queries/events.test.ts` に `getEventDetail` / `getEventStats` を追加。invalidatedAt 除外や companions の checkedIn 集計まで検証
- **C-2** `tests/db/actions/events.test.ts`（新規）で `createEvent` / `updateEvent` / `deleteEvent` / `updateEventStatus` を検証。JST 日付判定は `vi.useFakeTimers` + `vi.setSystemTime` で固定。`updateEventStatus` の遷移 16 パターンは `VALID_TRANSITIONS` を流用せず独立した期待マップで持つことで、定数を壊したときに赤くなる sanity check が成立するようにした
- **helpers/auth** の `loginAs` を `name` 付きに拡張（`createEvent` action が `session.user.name` を `displayName` 初期値に使うため）

## Test plan

- [x] `pnpm test:db`（5 files / 66 tests pass）
- [x] `pnpm type-check`
- [x] `pnpm lint`
- [x] Step C 完了時 sanity check: `VALID_TRANSITIONS.draft` を `[]` に壊すと当該テストが赤くなることを確認 → 戻した

🤖 Generated with [Claude Code](https://claude.com/claude-code)