### PR TITLE
test(actions/checkin): チェックインフローを検証 (issue #55 Step B)

### DIFF
--- a/tests/db/actions/checkin.test.ts
+++ b/tests/db/actions/checkin.test.ts
@@ -4,6 +4,7 @@ import {
   lookupInvitationByToken,
   performCheckIn,
   searchInvitationByName,
+  undoCheckIn,
 } from "@/app/(main)/events/[eventId]/checkin/_actions";
 import { db } from "@/db";
 import { companions, invitations } from "@/db/schema";
@@ -421,6 +422,139 @@ describe("performCheckIn", () => {
       status: "accepted",
     });
     const result = await performCheckIn(ownEvent.id, otherInv.id, "guest");
+    expect(result).toEqual({
+      error: expect.stringContaining("見つかりません"),
+    });
+  });
+});
+
+describe("undoCheckIn", () => {
+  it("guest: checkedIn=false + checkedInAt=null にリセット", async () => {
+    const { event, memberId } = await setupMember();
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+      checkedIn: true,
+      checkedInAt: 1234,
+    });
+
+    const result = await undoCheckIn(event.id, inv.id, "guest");
+    if ("error" in result) throw new Error(result.error);
+    expect(result.summary).toMatchObject({ checkedInGuests: 0 });
+
+    const after = await db.query.invitations.findFirst({
+      where: eq(invitations.id, inv.id),
+    });
+    expect(after).toMatchObject({ checkedIn: false, checkedInAt: null });
+  });
+
+  it("companion: 指定 id の同伴者だけリセット", async () => {
+    const { event, memberId } = await setupMember();
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+    });
+    const target = await addCompanion({
+      invitationId: inv.id,
+      checkedIn: true,
+      checkedInAt: 100,
+    });
+    const other = await addCompanion({
+      invitationId: inv.id,
+      checkedIn: true,
+      checkedInAt: 200,
+    });
+
+    const result = await undoCheckIn(event.id, inv.id, "companion", target.id);
+    if ("error" in result) throw new Error(result.error);
+
+    const targetRow = await db.query.companions.findFirst({
+      where: eq(companions.id, target.id),
+    });
+    const otherRow = await db.query.companions.findFirst({
+      where: eq(companions.id, other.id),
+    });
+    expect(targetRow).toMatchObject({ checkedIn: false, checkedInAt: null });
+    expect(otherRow).toMatchObject({ checkedIn: true, checkedInAt: 200 });
+  });
+
+  it("companion: targetId 未指定はエラー", async () => {
+    const { event, memberId } = await setupMember();
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+    });
+    const result = await undoCheckIn(event.id, inv.id, "companion");
+    expect(result).toEqual({ error: expect.stringContaining("同伴者ID") });
+  });
+
+  it("companion: 別招待配下の id は弾く", async () => {
+    const { event, memberId } = await setupMember();
+    const invA = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+    });
+    const invB = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+    });
+    const compB = await addCompanion({
+      invitationId: invB.id,
+      checkedIn: true,
+      checkedInAt: 100,
+    });
+
+    const result = await undoCheckIn(event.id, invA.id, "companion", compB.id);
+    expect(result).toEqual({ error: expect.stringContaining("同伴者") });
+
+    // invB 配下の同伴者は変わらない
+    const stillCheckedIn = await db.query.companions.findFirst({
+      where: eq(companions.id, compB.id),
+    });
+    expect(stillCheckedIn).toMatchObject({ checkedIn: true, checkedInAt: 100 });
+  });
+
+  it("ongoing 以外（finished 含む）では取り消し不可", async () => {
+    const { event, memberId } = await setupMember({ status: "finished" });
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+      checkedIn: true,
+      checkedInAt: 1,
+    });
+    const result = await undoCheckIn(event.id, inv.id, "guest");
+    expect(result).toEqual({ error: expect.stringContaining("開催中") });
+  });
+
+  it("非メンバーは取り消し不可", async () => {
+    const event = await createEvent({ status: "ongoing" });
+    const stranger = await createUser();
+    loginAs(stranger);
+    const result = await undoCheckIn(event.id, "any", "guest");
+    expect(result).toEqual({ error: "権限がありません" });
+  });
+
+  it("別イベント配下の invitationId はエラー", async () => {
+    const { event: ownEvent } = await setupMember();
+    const otherEvent = await createEvent({ status: "ongoing" });
+    const otherUser = await createUser();
+    const otherMember = await addEventMember({
+      eventId: otherEvent.id,
+      userId: otherUser.id,
+      role: "organizer",
+    });
+    const otherInv = await addInvitation({
+      eventId: otherEvent.id,
+      memberId: otherMember,
+      status: "accepted",
+    });
+    const result = await undoCheckIn(ownEvent.id, otherInv.id, "guest");
     expect(result).toEqual({
       error: expect.stringContaining("見つかりません"),
     });

--- a/tests/db/actions/checkin.test.ts
+++ b/tests/db/actions/checkin.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { searchInvitationByName } from "@/app/(main)/events/[eventId]/checkin/_actions";
+import {
+  lookupInvitationByToken,
+  searchInvitationByName,
+} from "@/app/(main)/events/[eventId]/checkin/_actions";
 import {
   addCompanion,
   addEventMember,
@@ -113,6 +116,111 @@ describe("searchInvitationByName", () => {
     const stranger = await createUser();
     loginAs(stranger);
     const result = await searchInvitationByName(event.id, "誰か");
+    expect(result).toEqual({ error: "権限がありません" });
+  });
+});
+
+describe("lookupInvitationByToken", () => {
+  it("accepted 招待の token から招待情報を返す", async () => {
+    const { event, memberId } = await setupMember();
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+      token: "tok-accepted",
+    });
+    await addCompanion({ invitationId: inv.id, name: "同伴者A" });
+
+    const result = await lookupInvitationByToken(event.id, "tok-accepted");
+    if ("error" in result) throw new Error(result.error);
+    expect(result.invitation.id).toBe(inv.id);
+    expect(result.invitation.companions).toHaveLength(1);
+    expect(result.invitation.companions[0]).toMatchObject({ name: "同伴者A" });
+  });
+
+  it("別イベントの token はエラー", async () => {
+    const { event: ownEvent } = await setupMember();
+    const otherEvent = await createEvent({ status: "ongoing" });
+    const otherUser = await createUser();
+    const otherMember = await addEventMember({
+      eventId: otherEvent.id,
+      userId: otherUser.id,
+      role: "organizer",
+    });
+    await addInvitation({
+      eventId: otherEvent.id,
+      memberId: otherMember,
+      status: "accepted",
+      token: "tok-other",
+    });
+    const result = await lookupInvitationByToken(ownEvent.id, "tok-other");
+    expect(result).toEqual({ error: expect.stringContaining("別のイベント") });
+  });
+
+  it("無効化された招待はエラー", async () => {
+    const { event, memberId } = await setupMember();
+    await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+      token: "tok-invalidated",
+      invalidatedAt: 1,
+    });
+    const result = await lookupInvitationByToken(event.id, "tok-invalidated");
+    expect(result).toEqual({ error: expect.stringContaining("無効化") });
+  });
+
+  it("pending / declined はそれぞれエラーメッセージが異なる", async () => {
+    const { event, memberId } = await setupMember();
+    await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "pending",
+      token: "tok-pending",
+    });
+    await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "declined",
+      token: "tok-declined",
+    });
+    const pendingResult = await lookupInvitationByToken(
+      event.id,
+      "tok-pending",
+    );
+    expect(pendingResult).toEqual({
+      error: expect.stringContaining("出欠回答"),
+    });
+    const declinedResult = await lookupInvitationByToken(
+      event.id,
+      "tok-declined",
+    );
+    expect(declinedResult).toEqual({ error: expect.stringContaining("辞退") });
+  });
+
+  it("存在しない token はエラー", async () => {
+    const { event } = await setupMember();
+    const result = await lookupInvitationByToken(event.id, "no-such-token");
+    expect(result).toEqual({ error: expect.stringContaining("無効") });
+  });
+
+  it("ongoing 以外のイベントではエラー", async () => {
+    const { event, memberId } = await setupMember({ status: "published" });
+    await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+      token: "tok-x",
+    });
+    const result = await lookupInvitationByToken(event.id, "tok-x");
+    expect(result).toEqual({ error: expect.stringContaining("開催中") });
+  });
+
+  it("非メンバーは検索不可", async () => {
+    const event = await createEvent({ status: "ongoing" });
+    const stranger = await createUser();
+    loginAs(stranger);
+    const result = await lookupInvitationByToken(event.id, "tok");
     expect(result).toEqual({ error: "権限がありません" });
   });
 });

--- a/tests/db/actions/checkin.test.ts
+++ b/tests/db/actions/checkin.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   lookupInvitationByToken,
+  performCheckIn,
   searchInvitationByName,
 } from "@/app/(main)/events/[eventId]/checkin/_actions";
+import { db } from "@/db";
+import { companions, invitations } from "@/db/schema";
 import {
   addCompanion,
   addEventMember,
@@ -222,5 +226,203 @@ describe("lookupInvitationByToken", () => {
     loginAs(stranger);
     const result = await lookupInvitationByToken(event.id, "tok");
     expect(result).toEqual({ error: "権限がありません" });
+  });
+});
+
+describe("performCheckIn", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("guest: checkedIn=true + checkedInAt セットして summary を返す", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2030-01-01T10:00:00Z"));
+    const { event, memberId } = await setupMember();
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+    });
+
+    const now = Date.now();
+    const result = await performCheckIn(event.id, inv.id, "guest");
+    if ("error" in result) throw new Error(result.error);
+    expect(result.checkedInAt).toBe(now);
+    expect(result.summary).toMatchObject({
+      totalAccepted: 1,
+      checkedInGuests: 1,
+    });
+
+    const after = await db.query.invitations.findFirst({
+      where: eq(invitations.id, inv.id),
+    });
+    expect(after).toMatchObject({ checkedIn: true, checkedInAt: now });
+  });
+
+  it("guest 二重チェックイン: 既存 checkedInAt がそのまま返る（冪等）", async () => {
+    const { event, memberId } = await setupMember();
+    const existing = 1_700_000_000_000;
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+      checkedIn: true,
+      checkedInAt: existing,
+    });
+
+    const result = await performCheckIn(event.id, inv.id, "guest");
+    if ("error" in result) throw new Error(result.error);
+    expect(result.checkedInAt).toBe(existing);
+
+    // DB の値が上書きされていない
+    const after = await db.query.invitations.findFirst({
+      where: eq(invitations.id, inv.id),
+    });
+    expect(after?.checkedInAt).toBe(existing);
+  });
+
+  it("companion: 指定 id の同伴者だけ checkedIn=true に更新される", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2030-01-01T10:00:00Z"));
+    const { event, memberId } = await setupMember();
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+    });
+    const target = await addCompanion({ invitationId: inv.id });
+    const other = await addCompanion({ invitationId: inv.id });
+
+    const now = Date.now();
+    const result = await performCheckIn(
+      event.id,
+      inv.id,
+      "companion",
+      target.id,
+    );
+    if ("error" in result) throw new Error(result.error);
+    expect(result.checkedInAt).toBe(now);
+
+    const targetRow = await db.query.companions.findFirst({
+      where: eq(companions.id, target.id),
+    });
+    const otherRow = await db.query.companions.findFirst({
+      where: eq(companions.id, other.id),
+    });
+    expect(targetRow).toMatchObject({ checkedIn: true, checkedInAt: now });
+    expect(otherRow).toMatchObject({ checkedIn: false, checkedInAt: null });
+  });
+
+  it("companion 二重チェックイン: 既存 checkedInAt がそのまま返る（冪等）", async () => {
+    const { event, memberId } = await setupMember();
+    const existing = 1_700_000_000_000;
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+    });
+    const c = await addCompanion({
+      invitationId: inv.id,
+      checkedIn: true,
+      checkedInAt: existing,
+    });
+    const result = await performCheckIn(event.id, inv.id, "companion", c.id);
+    if ("error" in result) throw new Error(result.error);
+    expect(result.checkedInAt).toBe(existing);
+  });
+
+  it("companion: targetId 未指定はエラー", async () => {
+    const { event, memberId } = await setupMember();
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+    });
+    const result = await performCheckIn(event.id, inv.id, "companion");
+    expect(result).toEqual({ error: expect.stringContaining("同伴者ID") });
+  });
+
+  it("companion: 別招待の同伴者 id を渡すとエラー", async () => {
+    const { event, memberId } = await setupMember();
+    const invA = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+    });
+    const invB = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+    });
+    const compB = await addCompanion({ invitationId: invB.id });
+    const result = await performCheckIn(
+      event.id,
+      invA.id,
+      "companion",
+      compB.id,
+    );
+    expect(result).toEqual({ error: expect.stringContaining("同伴者") });
+  });
+
+  it("ongoing 以外のイベントではエラー", async () => {
+    const { event, memberId } = await setupMember({ status: "published" });
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+    });
+    const result = await performCheckIn(event.id, inv.id, "guest");
+    expect(result).toEqual({ error: expect.stringContaining("開催中") });
+  });
+
+  it("accepted 以外の招待にはチェックインできない", async () => {
+    const { event, memberId } = await setupMember();
+    const pending = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "pending",
+    });
+    const result = await performCheckIn(event.id, pending.id, "guest");
+    expect(result).toEqual({ error: expect.stringContaining("出席") });
+  });
+
+  it("invalidated 招待にはチェックインできない", async () => {
+    const { event, memberId } = await setupMember();
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+      invalidatedAt: 1,
+    });
+    const result = await performCheckIn(event.id, inv.id, "guest");
+    expect(result).toEqual({ error: expect.stringContaining("無効化") });
+  });
+
+  it("非メンバーは実行不可", async () => {
+    const event = await createEvent({ status: "ongoing" });
+    const stranger = await createUser();
+    loginAs(stranger);
+    const result = await performCheckIn(event.id, "any", "guest");
+    expect(result).toEqual({ error: "権限がありません" });
+  });
+
+  it("別イベント配下の invitationId はエラー", async () => {
+    const { event: ownEvent } = await setupMember();
+    const otherEvent = await createEvent({ status: "ongoing" });
+    const otherUser = await createUser();
+    const otherMember = await addEventMember({
+      eventId: otherEvent.id,
+      userId: otherUser.id,
+      role: "organizer",
+    });
+    const otherInv = await addInvitation({
+      eventId: otherEvent.id,
+      memberId: otherMember,
+      status: "accepted",
+    });
+    const result = await performCheckIn(ownEvent.id, otherInv.id, "guest");
+    expect(result).toEqual({
+      error: expect.stringContaining("見つかりません"),
+    });
   });
 });

--- a/tests/db/actions/checkin.test.ts
+++ b/tests/db/actions/checkin.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { searchInvitationByName } from "@/app/(main)/events/[eventId]/checkin/_actions";
+import {
+  addCompanion,
+  addEventMember,
+  addInvitation,
+  createEvent,
+  createUser,
+} from "../factories";
+import { loginAs } from "../helpers/auth";
+
+async function setupMember(
+  eventOverrides: {
+    status?: "draft" | "published" | "ongoing" | "finished";
+    totalSeats?: number;
+  } = {},
+  role: "organizer" | "performer" = "organizer",
+) {
+  const user = await createUser();
+  const event = await createEvent({
+    status: "ongoing",
+    totalSeats: 10,
+    ...eventOverrides,
+  });
+  const memberId = await addEventMember({
+    eventId: event.id,
+    userId: user.id,
+    role,
+  });
+  loginAs(user);
+  return { user, event, memberId };
+}
+
+describe("searchInvitationByName", () => {
+  it("guestName の部分一致で accepted の招待を返す", async () => {
+    const { event, memberId } = await setupMember();
+    const matched = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+      guestName: "山田太郎",
+    });
+    // status=accepted 以外は除外される
+    await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "pending",
+      guestName: "山田花子",
+    });
+    await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "declined",
+      guestName: "山田次郎",
+    });
+    // 名前不一致
+    await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+      guestName: "鈴木一郎",
+    });
+
+    const result = await searchInvitationByName(event.id, "山田");
+    if ("error" in result) throw new Error(result.error);
+    expect(result.invitations).toHaveLength(1);
+    expect(result.invitations[0]).toMatchObject({
+      id: matched.id,
+      guestNameMatched: true,
+      matchedCompanionIds: [],
+    });
+  });
+
+  it("companion 名の部分一致でもヒットし、matchedCompanionIds が返る", async () => {
+    const { event, memberId } = await setupMember();
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+      guestName: "ゲスト",
+    });
+    const c1 = await addCompanion({
+      invitationId: inv.id,
+      name: "佐藤次郎",
+    });
+    await addCompanion({
+      invitationId: inv.id,
+      name: "別人",
+    });
+
+    const result = await searchInvitationByName(event.id, "佐藤");
+    if ("error" in result) throw new Error(result.error);
+    expect(result.invitations).toHaveLength(1);
+    expect(result.invitations[0].guestNameMatched).toBe(false);
+    expect(result.invitations[0].matchedCompanionIds).toEqual([c1.id]);
+  });
+
+  it("空文字クエリでは空配列を返す", async () => {
+    const { event } = await setupMember();
+    const result = await searchInvitationByName(event.id, "   ");
+    if ("error" in result) throw new Error(result.error);
+    expect(result.invitations).toEqual([]);
+  });
+
+  it("ongoing 以外のイベントではエラー", async () => {
+    const { event } = await setupMember({ status: "published" });
+    const result = await searchInvitationByName(event.id, "誰か");
+    expect(result).toEqual({ error: expect.stringContaining("開催中") });
+  });
+
+  it("非メンバーは検索不可", async () => {
+    const event = await createEvent({ status: "ongoing" });
+    const stranger = await createUser();
+    loginAs(stranger);
+    const result = await searchInvitationByName(event.id, "誰か");
+    expect(result).toEqual({ error: "権限がありません" });
+  });
+});


### PR DESCRIPTION
## Summary

issue #55 ステップ2 Step B（チェックイン）。`tests/db/actions/checkin.test.ts` を新規追加し、`src/app/(main)/events/[eventId]/checkin/_actions.ts` の 4 関数を網羅的に検証。

- `searchInvitationByName`: guestName / 同伴者名の部分一致、accepted 限定、ongoing 制約、権限ガード
- `lookupInvitationByToken`: 別イベント token 弾き、invalidated、status 別エラー分岐
- `performCheckIn`: guest / companion 分岐、二重チェックインの**冪等性**（既存 `checkedInAt` を返し DB を上書きしない）、ongoing / accepted / invalidated 制約、別招待・別イベントスコープ
- `undoCheckIn`: `checkedIn=false` + `checkedInAt=null` リセット、ongoing 限定、scope 検証

サブ項目ごとに 4 commit に分割しています。

## Test plan

- [x] `pnpm test:db` — 60/60 pass（既存 + 新規 30 件）
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [ ] plan の Step B 動作確認: 二重 check-in を弾く分岐を意図的に壊してテストが赤くなることを確認 → 戻す（フォロー）

🤖 Generated with [Claude Code](https://claude.com/claude-code)