### PR TITLE
test(programs): クエリと Server Action（tx 内整合性）の DB テスト追加

### DIFF
--- a/src/lib/queries/programs.test.ts
+++ b/src/lib/queries/programs.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  addEventMember,
+  addProgram,
+  addProgramPerformer,
+  addProgramPiece,
+  createEvent,
+  createUser,
+} from "../../../tests/db/factories";
+import { getProgramsByEventId } from "./programs";
+
+describe("getProgramsByEventId", () => {
+  it("sortOrder 昇順で返し、performers と pieces を結合する", async () => {
+    const event = await createEvent();
+    const user = await createUser();
+    const memberId = await addEventMember({
+      eventId: event.id,
+      userId: user.id,
+      role: "performer",
+      displayName: "出演者A",
+    });
+
+    const p2 = await addProgram({
+      eventId: event.id,
+      sortOrder: 2,
+      type: "performance",
+    });
+    const p1 = await addProgram({
+      eventId: event.id,
+      sortOrder: 1,
+      type: "intermission",
+    });
+
+    // p2 に pieces / performer を紐付け（sortOrder 逆順で挿入して並び順を検証）
+    await addProgramPiece({
+      programId: p2.id,
+      sortOrder: 2,
+      title: "曲B",
+      composer: "作曲家B",
+    });
+    await addProgramPiece({
+      programId: p2.id,
+      sortOrder: 1,
+      title: "曲A",
+      composer: null,
+    });
+    await addProgramPerformer({ programId: p2.id, memberId });
+
+    const result = await getProgramsByEventId(event.id);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe(p1.id);
+    expect(result[1].id).toBe(p2.id);
+
+    expect(result[1].pieces.map((pc) => pc.title)).toEqual(["曲A", "曲B"]);
+    expect(result[1].performers).toEqual([
+      { id: expect.any(String), memberId, displayName: "出演者A" },
+    ]);
+    expect(result[0].pieces).toEqual([]);
+    expect(result[0].performers).toEqual([]);
+  });
+
+  it("他イベントのプログラムは含めない", async () => {
+    const event = await createEvent();
+    const other = await createEvent();
+    await addProgram({ eventId: other.id, sortOrder: 1 });
+
+    const result = await getProgramsByEventId(event.id);
+    expect(result).toEqual([]);
+  });
+});

--- a/tests/db/actions/programs.test.ts
+++ b/tests/db/actions/programs.test.ts
@@ -1,0 +1,149 @@
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import {
+  createProgram,
+  deleteProgram,
+  reorderPrograms,
+  updateProgram,
+} from "@/app/(main)/events/[eventId]/programs/_actions";
+import { db } from "@/db";
+import { programPerformers, programPieces, programs } from "@/db/schema";
+import {
+  addEventMember,
+  addProgram,
+  addProgramPerformer,
+  addProgramPiece,
+  createEvent,
+  createUser,
+} from "../factories";
+import { loginAs } from "../helpers/auth";
+
+async function setupOrganizer(
+  eventOverrides: {
+    status?: "draft" | "published" | "ongoing" | "finished";
+  } = {},
+) {
+  const user = await createUser();
+  const event = await createEvent({ status: "published", ...eventOverrides });
+  const organizerMemberId = await addEventMember({
+    eventId: event.id,
+    userId: user.id,
+    role: "organizer",
+    displayName: "主催者",
+  });
+  loginAs(user);
+  return { user, event, organizerMemberId };
+}
+
+const baseInput = {
+  type: "performance" as const,
+  pieces: [{ title: "曲A", composer: "作曲家A" }],
+  scheduledTime: "",
+  estimatedDuration: "",
+  note: "",
+  performerIds: [] as string[],
+};
+
+describe("createProgram", () => {
+  it("sortOrder は既存最大 +1 を採番し、tx 内で pieces / performers が挿入される", async () => {
+    const { event, organizerMemberId } = await setupOrganizer();
+    await addProgram({ eventId: event.id, sortOrder: 1 });
+    await addProgram({ eventId: event.id, sortOrder: 5 });
+
+    const result = await createProgram(event.id, {
+      ...baseInput,
+      pieces: [
+        { title: "1曲目", composer: "X" },
+        { title: "2曲目", composer: "" },
+      ],
+      performerIds: [organizerMemberId],
+    });
+    expect(result).toBeNull();
+
+    const created = await db.query.programs.findMany({
+      where: eq(programs.eventId, event.id),
+      orderBy: (t, { asc }) => [asc(t.sortOrder)],
+    });
+    expect(created.map((p) => p.sortOrder)).toEqual([1, 5, 6]);
+
+    const newProgram = created[2];
+    const pieces = await db
+      .select()
+      .from(programPieces)
+      .where(eq(programPieces.programId, newProgram.id));
+    expect(pieces).toHaveLength(2);
+    expect(
+      pieces.sort((a, b) => a.sortOrder - b.sortOrder).map((p) => p.title),
+    ).toEqual(["1曲目", "2曲目"]);
+    // composer の "" は null に正規化される
+    expect(pieces.find((p) => p.title === "2曲目")?.composer).toBeNull();
+
+    const performers = await db
+      .select()
+      .from(programPerformers)
+      .where(eq(programPerformers.programId, newProgram.id));
+    expect(performers).toHaveLength(1);
+    expect(performers[0].memberId).toBe(organizerMemberId);
+  });
+
+  it("最初のプログラムは sortOrder = 1", async () => {
+    const { event } = await setupOrganizer();
+    const result = await createProgram(event.id, {
+      ...baseInput,
+      type: "intermission",
+      pieces: [{ title: "休憩", composer: "" }],
+    });
+    expect(result).toBeNull();
+
+    const rows = await db.query.programs.findMany({
+      where: eq(programs.eventId, event.id),
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].sortOrder).toBe(1);
+  });
+
+  it("performance タイプで出演者ゼロは fieldErrors を返す", async () => {
+    const { event } = await setupOrganizer();
+    const result = await createProgram(event.id, {
+      ...baseInput,
+      performerIds: [],
+    });
+    expect(result?.fieldErrors?.performerIds).toBeTruthy();
+    const rows = await db.query.programs.findMany({
+      where: eq(programs.eventId, event.id),
+    });
+    expect(rows).toHaveLength(0);
+  });
+
+  it("他イベントの member を performerIds に混ぜるとエラー", async () => {
+    const { event } = await setupOrganizer();
+    const otherEvent = await createEvent({ status: "published" });
+    const otherUser = await createUser();
+    const otherMemberId = await addEventMember({
+      eventId: otherEvent.id,
+      userId: otherUser.id,
+      role: "performer",
+    });
+
+    const result = await createProgram(event.id, {
+      ...baseInput,
+      performerIds: [otherMemberId],
+    });
+    expect(result?.error).toMatch(/出演者/);
+    const rows = await db.query.programs.findMany({
+      where: eq(programs.eventId, event.id),
+    });
+    expect(rows).toHaveLength(0);
+  });
+
+  it("finished イベントでは作成不可", async () => {
+    const { event, organizerMemberId } = await setupOrganizer({
+      status: "finished",
+    });
+    const result = await createProgram(event.id, {
+      ...baseInput,
+      performerIds: [organizerMemberId],
+    });
+    expect(result?.error).toMatch(/終了/);
+  });
+});

--- a/tests/db/actions/programs.test.ts
+++ b/tests/db/actions/programs.test.ts
@@ -147,3 +147,166 @@ describe("createProgram", () => {
     expect(result?.error).toMatch(/終了/);
   });
 });
+
+describe("updateProgram", () => {
+  it("pieces / performers を tx 内で全削除→再 INSERT する（旧データは消える）", async () => {
+    const { event, organizerMemberId } = await setupOrganizer();
+
+    const performerUser = await createUser();
+    const performerMemberId = await addEventMember({
+      eventId: event.id,
+      userId: performerUser.id,
+      role: "performer",
+      displayName: "出演者B",
+    });
+
+    const program = await addProgram({
+      eventId: event.id,
+      sortOrder: 1,
+      type: "performance",
+    });
+    const oldPiece = await addProgramPiece({
+      programId: program.id,
+      sortOrder: 1,
+      title: "旧曲",
+    });
+    const oldPerformer = await addProgramPerformer({
+      programId: program.id,
+      memberId: organizerMemberId,
+    });
+
+    const result = await updateProgram(event.id, program.id, {
+      ...baseInput,
+      pieces: [
+        { title: "新曲1", composer: "X" },
+        { title: "新曲2", composer: "" },
+      ],
+      performerIds: [performerMemberId],
+    });
+    expect(result).toBeNull();
+
+    // 旧データが残っていない
+    const oldPieceStill = await db
+      .select()
+      .from(programPieces)
+      .where(eq(programPieces.id, oldPiece.id));
+    expect(oldPieceStill).toHaveLength(0);
+    const oldPerformerStill = await db
+      .select()
+      .from(programPerformers)
+      .where(eq(programPerformers.id, oldPerformer.id));
+    expect(oldPerformerStill).toHaveLength(0);
+
+    // 新データが整合的に挿入されている
+    const pieces = await db
+      .select()
+      .from(programPieces)
+      .where(eq(programPieces.programId, program.id));
+    expect(pieces).toHaveLength(2);
+    expect(
+      pieces.sort((a, b) => a.sortOrder - b.sortOrder).map((p) => p.title),
+    ).toEqual(["新曲1", "新曲2"]);
+
+    const performers = await db
+      .select()
+      .from(programPerformers)
+      .where(eq(programPerformers.programId, program.id));
+    expect(performers).toHaveLength(1);
+    expect(performers[0].memberId).toBe(performerMemberId);
+  });
+
+  it("performerIds を空にすると performers が空になる（intermission 等）", async () => {
+    const { event, organizerMemberId } = await setupOrganizer();
+    const program = await addProgram({
+      eventId: event.id,
+      sortOrder: 1,
+      type: "performance",
+    });
+    await addProgramPerformer({
+      programId: program.id,
+      memberId: organizerMemberId,
+    });
+
+    const result = await updateProgram(event.id, program.id, {
+      ...baseInput,
+      type: "intermission",
+      pieces: [{ title: "休憩", composer: "" }],
+      performerIds: [],
+    });
+    expect(result).toBeNull();
+
+    const performers = await db
+      .select()
+      .from(programPerformers)
+      .where(eq(programPerformers.programId, program.id));
+    expect(performers).toHaveLength(0);
+  });
+
+  it("バリデーションエラー時は既存 pieces / performers を破壊しない", async () => {
+    const { event, organizerMemberId } = await setupOrganizer();
+    const program = await addProgram({
+      eventId: event.id,
+      sortOrder: 1,
+      type: "performance",
+    });
+    await addProgramPiece({
+      programId: program.id,
+      sortOrder: 1,
+      title: "残るべき曲",
+    });
+    await addProgramPerformer({
+      programId: program.id,
+      memberId: organizerMemberId,
+    });
+
+    // performance タイプで performerIds 空 → fieldErrors
+    const result = await updateProgram(event.id, program.id, {
+      ...baseInput,
+      performerIds: [],
+    });
+    expect(result?.fieldErrors?.performerIds).toBeTruthy();
+
+    const pieces = await db
+      .select()
+      .from(programPieces)
+      .where(eq(programPieces.programId, program.id));
+    expect(pieces).toHaveLength(1);
+    const performers = await db
+      .select()
+      .from(programPerformers)
+      .where(eq(programPerformers.programId, program.id));
+    expect(performers).toHaveLength(1);
+  });
+
+  it("他イベントの programId は更新できない", async () => {
+    const { event, organizerMemberId } = await setupOrganizer();
+    const otherEvent = await createEvent({ status: "published" });
+    const otherProgram = await addProgram({
+      eventId: otherEvent.id,
+      sortOrder: 1,
+    });
+
+    const result = await updateProgram(event.id, otherProgram.id, {
+      ...baseInput,
+      performerIds: [organizerMemberId],
+    });
+    expect(result?.error).toMatch(/見つかりません/);
+  });
+
+  it("finished イベントでは更新不可", async () => {
+    const { event, organizerMemberId } = await setupOrganizer({
+      status: "finished",
+    });
+    const program = await addProgram({
+      eventId: event.id,
+      sortOrder: 1,
+      type: "performance",
+    });
+
+    const result = await updateProgram(event.id, program.id, {
+      ...baseInput,
+      performerIds: [organizerMemberId],
+    });
+    expect(result?.error).toMatch(/終了/);
+  });
+});

--- a/tests/db/actions/programs.test.ts
+++ b/tests/db/actions/programs.test.ts
@@ -356,3 +356,68 @@ describe("reorderPrograms", () => {
     expect(result?.error).toMatch(/終了/);
   });
 });
+
+describe("deleteProgram", () => {
+  it("CASCADE で pieces / performers が消える", async () => {
+    const { event, organizerMemberId } = await setupOrganizer();
+    const program = await addProgram({
+      eventId: event.id,
+      sortOrder: 1,
+      type: "performance",
+    });
+    await addProgramPiece({ programId: program.id, sortOrder: 1, title: "曲" });
+    await addProgramPerformer({
+      programId: program.id,
+      memberId: organizerMemberId,
+    });
+
+    const result = await deleteProgram(event.id, program.id);
+    expect(result).toBeNull();
+
+    const remaining = await db
+      .select()
+      .from(programs)
+      .where(eq(programs.id, program.id));
+    expect(remaining).toHaveLength(0);
+
+    const pieces = await db
+      .select()
+      .from(programPieces)
+      .where(eq(programPieces.programId, program.id));
+    expect(pieces).toHaveLength(0);
+
+    const performers = await db
+      .select()
+      .from(programPerformers)
+      .where(eq(programPerformers.programId, program.id));
+    expect(performers).toHaveLength(0);
+  });
+
+  it("他イベントの programId は削除対象に含めても消えない（eventId 一致のみ）", async () => {
+    const { event } = await setupOrganizer();
+    const otherEvent = await createEvent({ status: "published" });
+    const foreign = await addProgram({ eventId: otherEvent.id, sortOrder: 1 });
+
+    const result = await deleteProgram(event.id, foreign.id);
+    expect(result).toBeNull();
+
+    const stillThere = await db
+      .select()
+      .from(programs)
+      .where(eq(programs.id, foreign.id));
+    expect(stillThere).toHaveLength(1);
+  });
+
+  it("finished イベントでは削除不可", async () => {
+    const { event } = await setupOrganizer({ status: "finished" });
+    const program = await addProgram({ eventId: event.id, sortOrder: 1 });
+    const result = await deleteProgram(event.id, program.id);
+    expect(result?.error).toMatch(/終了/);
+
+    const stillThere = await db
+      .select()
+      .from(programs)
+      .where(eq(programs.id, program.id));
+    expect(stillThere).toHaveLength(1);
+  });
+});

--- a/tests/db/actions/programs.test.ts
+++ b/tests/db/actions/programs.test.ts
@@ -310,3 +310,49 @@ describe("updateProgram", () => {
     expect(result?.error).toMatch(/終了/);
   });
 });
+
+describe("reorderPrograms", () => {
+  it("配列 index 通りに sortOrder を 1..N に再付番する", async () => {
+    const { event } = await setupOrganizer();
+    const a = await addProgram({ eventId: event.id, sortOrder: 10 });
+    const b = await addProgram({ eventId: event.id, sortOrder: 20 });
+    const c = await addProgram({ eventId: event.id, sortOrder: 30 });
+
+    const result = await reorderPrograms(event.id, [c.id, a.id, b.id]);
+    expect(result).toBeNull();
+
+    const rows = await db.query.programs.findMany({
+      where: eq(programs.eventId, event.id),
+    });
+    const byId = Object.fromEntries(rows.map((r) => [r.id, r.sortOrder]));
+    expect(byId[c.id]).toBe(1);
+    expect(byId[a.id]).toBe(2);
+    expect(byId[b.id]).toBe(3);
+  });
+
+  it("他イベントの programId は更新対象に含めても黙って無視される（自イベントの分のみ更新）", async () => {
+    const { event } = await setupOrganizer();
+    const otherEvent = await createEvent({ status: "published" });
+    const own = await addProgram({ eventId: event.id, sortOrder: 5 });
+    const foreign = await addProgram({ eventId: otherEvent.id, sortOrder: 9 });
+
+    const result = await reorderPrograms(event.id, [foreign.id, own.id]);
+    expect(result).toBeNull();
+
+    const ownAfter = await db.query.programs.findFirst({
+      where: eq(programs.id, own.id),
+    });
+    const foreignAfter = await db.query.programs.findFirst({
+      where: eq(programs.id, foreign.id),
+    });
+    expect(ownAfter?.sortOrder).toBe(2);
+    expect(foreignAfter?.sortOrder).toBe(9);
+  });
+
+  it("finished イベントでは並び替え不可", async () => {
+    const { event } = await setupOrganizer({ status: "finished" });
+    const p = await addProgram({ eventId: event.id, sortOrder: 1 });
+    const result = await reorderPrograms(event.id, [p.id]);
+    expect(result?.error).toMatch(/終了/);
+  });
+});


### PR DESCRIPTION
## Summary

issue #55 ステップ2 の **Step D（programs tx）** を実装。`feat/db-test-foundation` で整備した DB テスト基盤の上に、programs クエリと Server Action のテストを追加します。

- `src/lib/queries/programs.test.ts`: `getProgramsByEventId` の sortOrder 並び順と performers / pieces 結合
- `tests/db/actions/programs.test.ts`:
  - `createProgram`: 既存最大 +1 採番、tx 内 pieces / performers 同時挿入、performance 出演者必須、他イベント member 拒否、finished 制限
  - `updateProgram`: tx 内 pieces / performers 全削除→再 INSERT、バリデーション失敗時の既存破壊なし、他イベント programId 拒否、finished 制限
  - `reorderPrograms`: 配列 index 通りに 1..N 採番、他イベント分の sortOrder は変えない、finished 制限
  - `deleteProgram`: CASCADE で pieces / performers が消える、他イベント分は消えない、finished 制限

コミットはサブ項目（クエリ / create / update / reorder / delete）単位で 5 本に分けています。

## Test plan

- [x] `pnpm test:db` 全 green（48 tests）
- [x] `pnpm lint` 全 green
- [x] `pnpm type-check` 全 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)