### PR TITLE
ci: vitest を project 別 matrix で並列化（#55 step 3）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,12 @@ jobs:
       - run: pnpm type-check
 
   test:
-    name: Test
+    name: Test (${{ matrix.project }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        project: [unit, db, storybook]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -45,5 +49,6 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: npx playwright install chromium --with-deps
-      - run: pnpm vitest run
+      - if: matrix.project == 'storybook'
+        run: npx playwright install chromium --with-deps
+      - run: pnpm vitest run --project ${{ matrix.project }}


### PR DESCRIPTION
## Summary
- Test job を `unit` / `db` / `storybook` の matrix に分割し、failure の切り分けと並列化を改善
- playwright のインストールは storybook job 限定にし、unit / db を高速化
- DB テストの基盤（`tests/db/setup.ts` で migrations 実行 + transaction rollback）は既存のまま、CI でも `--project db` 指定で確実に走らせる

#55 step 3（GitHub Actions で実行する）の対応です。

## Test plan
- [ ] CI で `Test (unit)` `Test (db)` `Test (storybook)` の 3 job がすべて success
- [ ] storybook job 以外で playwright がインストールされていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)