### PR TITLE
chore: Renovate を導入

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":pinDevDependencies",
+    ":automergePatch",
+    "monorepo:nextjs",
+    "monorepo:storybook",
+    "group:nextjs",
+    "group:storybook"
+  ],
+  "rangeStrategy": "pin",
+  "timezone": "Asia/Tokyo",
+  "packageRules": [
+    {
+      "matchDepTypes": ["devDependencies"],
+      "groupName": "devDependencies",
+      "groupSlug": "dev-dependencies"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "pinDigests": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- npm 依存は exact version で pin（`rangeStrategy: pin`）
- devDependencies / Next.js / Storybook をそれぞれ 1 つの PR にまとめる
- GitHub Actions のバージョン参照を SHA で pin（`pinDigests`）
- patch update は automerge（`:automergePatch`）

## Test plan
- [ ] PR マージ後、GitHub に Renovate App を install
- [ ] onboarding PR が作成されること
- [ ] onboarding PR の中で grouping / pin 設定が意図通り反映されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)