### PR TITLE
fix(renovate): 存在しない group preset を削除

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,9 +5,7 @@
     ":pinDevDependencies",
     ":automergePatch",
     "monorepo:nextjs",
-    "monorepo:storybook",
-    "group:nextjs",
-    "group:storybook"
+    "monorepo:storybook"
   ],
   "rangeStrategy": "pin",
   "timezone": "Asia/Tokyo",


### PR DESCRIPTION
## Summary
Renovate 実行時に以下のエラーで config-validation に失敗していたため修正。

```
Cannot find preset's package (group:nextjs)
```

`group:nextjs` / `group:storybook` という preset は存在しない。`config:recommended` 内の `group:monorepos` が `monorepo:*` で定義されたパッケージ群を自動で 1 group にまとめてくれるため、別途 `group:*` を extends する必要はない。

## Test plan
- [x] `pnpm lint` で format check が通ること
- [ ] PR マージ後、Renovate の next 実行で config-validation が通ること