### PR TITLE
chore: Node バージョンを package.json / mise.toml で管理

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: package.json
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
@@ -29,7 +29,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: package.json
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm type-check
@@ -46,7 +46,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: package.json
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - if: matrix.project == 'storybook'

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+node = "lts"
+pnpm = "10.13.1"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "db:studio": "drizzle-kit studio"
   },
   "packageManager": "pnpm@10.13.1",
+  "engines": {
+    "node": "24.x"
+  },
   "pnpm": {
     "onlyBuiltDependencies": [
       "lefthook"


### PR DESCRIPTION
## Summary
- `package.json` に `engines.node = "24.x"` を追加し、CI（`actions/setup-node` の `node-version-file: package.json`）から参照するようにした
- プロジェクトに `mise.toml` を追加し、ローカルは `node = "lts"` で追従、`pnpm` も合わせて固定
- `ci.yml` の 3 job 全てを `node-version-file: package.json` に変更（ベタ書き `node-version: 22` を排除）

これにより Node のバージョン管理が package.json と mise.toml に集約される。

## Test plan
- [ ] CI（lint / type-check / test）がすべて green
- [ ] ローカルで `mise current` が node 24.x を指している