### PR TITLE
サイドナビ UX を磨く: 状態表現とアクセシビリティ

### DIFF
--- a/src/app/_components/navigation-sheet.stories.tsx
+++ b/src/app/_components/navigation-sheet.stories.tsx
@@ -1,6 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { NavigationSheet } from "./navigation-sheet";
 
+const allStatusEvents = [
+  { id: "evt-draft", name: "下書きの発表会", status: "draft" as const },
+  { id: "evt-published", name: "夏のリサイタル", status: "published" as const },
+  { id: "evt-ongoing", name: "本番進行中の会", status: "ongoing" as const },
+  { id: "evt-finished", name: "去年の発表会", status: "finished" as const },
+];
+
 const meta = {
   component: NavigationSheet,
   args: {
@@ -33,6 +40,34 @@ export const EventsNewActive: Story = {
     nextjs: {
       navigation: {
         pathname: "/events/new",
+      },
+    },
+  },
+};
+
+export const AllStatuses: Story = {
+  args: {
+    events: allStatusEvents,
+  },
+  parameters: {
+    nextjs: {
+      navigation: {
+        pathname: "/dashboard",
+      },
+    },
+  },
+};
+
+export const SubPageActive: Story = {
+  args: {
+    events: [
+      { id: "evt-ongoing", name: "本番進行中の会", status: "ongoing" as const },
+    ],
+  },
+  parameters: {
+    nextjs: {
+      navigation: {
+        pathname: "/events/evt-ongoing/programs",
       },
     },
   },

--- a/src/app/_components/navigation-sheet.tsx
+++ b/src/app/_components/navigation-sheet.tsx
@@ -170,7 +170,7 @@ function EventNavItem({
           <span className="flex items-center gap-1.5 text-[10px] tracking-wider text-muted-foreground/80">
             <span
               aria-hidden
-              className={`size-1.5 rounded-full ${statusDotClass[event.status]} ${event.status === "ongoing" ? "animate-pulse" : ""}`}
+              className={`size-1.5 rounded-full ${statusDotClass[event.status]} ${event.status === "ongoing" ? "motion-safe:animate-pulse" : ""}`}
             />
             {statusLabels[event.status]}
           </span>

--- a/src/app/_components/navigation-sheet.tsx
+++ b/src/app/_components/navigation-sheet.tsx
@@ -13,12 +13,13 @@ import {
 import {
   Sheet,
   SheetContent,
+  SheetDescription,
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
 import type { EventStatus } from "@/db/schema";
 import { authClient } from "@/lib/auth-client";
-import { statusLabels } from "@/lib/event-status";
+import { statusDotClass, statusLabels } from "@/lib/event-status";
 
 const navItems = [
   { href: "/dashboard", label: "ホーム", icon: House },
@@ -59,6 +60,9 @@ export function NavigationSheet({
           <SheetTitle className="font-serif text-lg font-light tracking-widest text-primary">
             Lull
           </SheetTitle>
+          <SheetDescription className="sr-only">
+            サイト内のページとマイイベントへのナビゲーション
+          </SheetDescription>
         </SheetHeader>
 
         <nav className="mt-8 flex flex-1 flex-col gap-1 overflow-y-auto">
@@ -69,6 +73,7 @@ export function NavigationSheet({
                 key={href}
                 href={href}
                 onClick={close}
+                aria-current={isActive ? "page" : undefined}
                 className={`flex items-center gap-3 rounded-md px-3 py-2.5 text-sm transition-colors duration-200 ${
                   isActive
                     ? "border-l-2 border-primary bg-accent/50 font-medium text-foreground"
@@ -150,6 +155,7 @@ function EventNavItem({
         <button
           type="button"
           aria-expanded={open}
+          aria-current={isWithinEvent ? "true" : undefined}
           className={`flex w-full items-center gap-2 rounded-md px-3 py-2.5 text-left text-sm transition-colors duration-200 ${
             isWithinEvent
               ? "bg-accent/40 text-foreground"
@@ -160,8 +166,12 @@ function EventNavItem({
             weight="light"
             className={`size-3 shrink-0 transition-transform duration-200 ${open ? "rotate-0" : "-rotate-90"}`}
           />
-          <span className="flex-1 truncate">{event.name}</span>
-          <span className="text-[10px] tracking-wider text-muted-foreground/80">
+          <span className="flex-1 truncate font-serif">{event.name}</span>
+          <span className="flex items-center gap-1.5 text-[10px] tracking-wider text-muted-foreground/80">
+            <span
+              aria-hidden
+              className={`size-1.5 rounded-full ${statusDotClass[event.status]} ${event.status === "ongoing" ? "animate-pulse" : ""}`}
+            />
             {statusLabels[event.status]}
           </span>
         </button>
@@ -171,13 +181,14 @@ function EventNavItem({
           {subItems.map((item) => {
             const isActive = pathname === item.href;
             return (
-              <li key={item.href}>
+              <li key={item.href} className="relative">
                 <Link
                   href={item.href}
                   onClick={onNavigate}
+                  aria-current={isActive ? "page" : undefined}
                   className={`flex items-center rounded-md px-3 py-2 text-xs transition-colors duration-200 ${
                     isActive
-                      ? "bg-accent/40 font-medium text-foreground"
+                      ? "bg-accent/40 font-medium text-foreground before:absolute before:-left-3 before:top-1.5 before:bottom-1.5 before:w-0.5 before:rounded-full before:bg-primary/70"
                       : "text-muted-foreground hover:bg-accent/30 hover:text-foreground"
                   }`}
                 >

--- a/src/lib/event-status.ts
+++ b/src/lib/event-status.ts
@@ -26,3 +26,11 @@ export const transitionLabels: Record<EventStatus, string> = {
   ongoing: "開催を開始",
   finished: "終了する",
 };
+
+/** ナビ等で使うステータス・ドットの色クラス（Tailwind） */
+export const statusDotClass: Record<EventStatus, string> = {
+  draft: "bg-muted-foreground/40",
+  published: "bg-primary",
+  ongoing: "bg-accent",
+  finished: "bg-muted-foreground/25",
+};


### PR DESCRIPTION
## Summary

- ステータス表示を「色ドット + ラベル」に置換、ongoing のみ `animate-pulse` で動きを示す
- イベント名に `font-serif` (Shippori Mincho) を適用し kinari × 明朝の世界観に揃える
- アクティブ判定を `aria-current="page"` / 親 Collapsible トリガーは `"true"` で意味分け
- サブページアクティブ時、`before:` 擬似要素で primary 色の縦バーを重ね親子の階層感を強調
- `SheetContent` の `aria-describedby` 警告を sr-only な `SheetDescription` で解消
- ステータス色クラスを `lib/event-status.ts` に `statusDotClass` として集約（`Record<EventStatus, string>` で将来 status 追加時の漏れを型で防止）

## 背景

`/dashboard` 等で表示されるサイドナビ（Sheet ベース）の UX を磨く依頼。元の表示は `[10px]` の生テキストでステータスを描画しており視認性が弱く、サブページのアクティブ表示も親ナビとの階層関係が見えにくい状態だった。今回はデスクトップ常設化や情報構造の見直しはスコープ外とし、既存の Sheet 構造を維持したまま表現とアクセシビリティを底上げする方針 (A 案) で対応。

## Test plan

- [x] `pnpm type-check` PASS
- [x] `pnpm exec biome check` (該当 3 ファイル) PASS
- [x] 実機 (`NEXT_PUBLIC_VERCEL_ENV=preview pnpm dev`) でハンバーガー → サイドナビを開き、`/dashboard` でホーム / `/events/.../programs` でサブページがそれぞれ正しくアクティブ表示
- [x] aria-current の値を実機で検証（リーフ Link は `"page"`、親トリガーは `"true"`）
- [x] reload 後の console: Errors 0 / Warnings 0（DialogContent の警告解消を確認）
- [ ] `AllStatuses` story で 4 status のドット色差・`ongoing` の pulse を目視
- [ ] `SubPageActive` story でサブページ行の primary 色縦バーを目視

🤖 Generated with [Claude Code](https://claude.com/claude-code)