### PR TITLE
chore: dev:preview スクリプトを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
+    "dev:preview": "NEXT_PUBLIC_VERCEL_ENV=preview next dev",
     "build": "next build && serwist build",
     "start": "next start",
     "lint": "biome check .",


### PR DESCRIPTION
## Summary
- `NEXT_PUBLIC_VERCEL_ENV=preview` を付与した `next dev` 起動用の npm script を追加
- `pnpm dev:preview` でローカルから emulate 経路（`@emulators/google` など）を有効化した状態で開発サーバーを立ち上げられるようにする

## Test plan
- [ ] `pnpm dev:preview` で起動し、`process.env.NEXT_PUBLIC_VERCEL_ENV === "preview"` 経路（`src/lib/env.ts` の `isPreview`）が true になることを確認
- [ ] サインイン等で emulate stub が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)