### PR TITLE
chore(renovate): @emulators/* をグルーピング

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,11 @@
       "groupSlug": "dev-dependencies"
     },
     {
+      "matchPackageNames": ["@emulators/**"],
+      "groupName": "emulators",
+      "groupSlug": "emulators"
+    },
+    {
       "matchManagers": ["github-actions"],
       "pinDigests": true
     }


### PR DESCRIPTION
## Summary
- `@emulators/*` 配下のパッケージ（`@emulators/adapter-next`, `@emulators/google` 等）を 1 つの PR にまとめるよう Renovate に packageRule を追加

## Test plan
- [ ] Renovate Dependency Dashboard / 次回スキャンで `@emulators/*` の更新が単一 PR にまとまることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)