### PR TITLE
fix: regenerate pnpm-lock.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2358,14 +2358,6 @@ packages:
       browserslist:
         optional: true
 
-  '@serwist/utils@9.5.9':
-    resolution: {integrity: sha512-WUsxogHrW9DBVIJZOYxrQmQ3SBRaMugCi7daFumHPU1KOfBJIuJpXZQ/yJItz58h8g9572skfoZwrIYv4rxbPQ==}
-    peerDependencies:
-      browserslist: '>=4'
-    peerDependenciesMeta:
-      browserslist:
-        optional: true
-
   '@serwist/webpack-plugin@9.5.8':
     resolution: {integrity: sha512-9LiQoJ0cpzecy95xz3G8w+qLxIKrNosDA6/f/FBsg6gAHRiYY4i9/zb//33zsm4eEKHi2YQEuPqor8DPTJm1og==}
     engines: {node: '>=18.0.0'}
@@ -6426,10 +6418,6 @@ snapshots:
       - webpack
 
   '@serwist/utils@9.5.8(browserslist@4.28.2)':
-    optionalDependencies:
-      browserslist: 4.28.2
-
-  '@serwist/utils@9.5.9(browserslist@4.28.2)':
     optionalDependencies:
       browserslist: 4.28.2
 


### PR DESCRIPTION
## Summary
- `pnpm install` で lockfile を再生成し、依存解決上不要だった `@serwist/utils@9.5.9` のエントリを削除
- `pnpm install --frozen-lockfile` が通る状態に整合

## Test plan
- [x] `pnpm install --frozen-lockfile` が成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)