### PR TITLE
chore: 依存更新に 3 日の cooldown を設定

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 4320

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
   ],
   "rangeStrategy": "pin",
   "timezone": "Asia/Tokyo",
+  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],


### PR DESCRIPTION
## Summary
- pnpm と Renovate の双方で、公開から 3 日経っていないバージョンを取り込まないように設定
- `pnpm-workspace.yaml` 新設で `minimumReleaseAge: 4320`（= 3 日 × 24 時間 × 60 分）
- `renovate.json` に `"minimumReleaseAge": "3 days"` を追加

## なぜ
供給連鎖攻撃で compromised なバージョンが公開されても、cooldown 期間内にレジストリ側で削除されれば install / PR 化を回避できる。pnpm は install 時の防御、Renovate は PR 作成時の防御で二段構えにする。

## 例外
緊急の hotfix を取り込みたい場合は、それぞれ以下で個別除外できる:
- pnpm: `pnpm-workspace.yaml` の `minimumReleaseAgeExclude`
- Renovate: `packageRules` で対象パッケージに対して `minimumReleaseAge: "0"`

## Test plan
- [ ] Renovate の次回実行で、公開直後のバージョンに対する PR が作られないこと
- [ ] `pnpm install` が問題なく通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)