### PR TITLE
refactor(design-system): primary/accent を墨色トーンに刷新

### DIFF
--- a/src/app/_components/app-header.tsx
+++ b/src/app/_components/app-header.tsx
@@ -43,7 +43,7 @@ export function AppHeader({ events = [] }: AppHeaderProps) {
           <Link
             href="/dashboard"
             aria-label="ホームへ"
-            className="font-serif text-lg font-light tracking-widest text-primary"
+            className="font-serif text-lg font-light tracking-widest text-brand"
           >
             Lull
           </Link>

--- a/src/app/_components/navigation-sheet.tsx
+++ b/src/app/_components/navigation-sheet.tsx
@@ -57,7 +57,7 @@ export function NavigationSheet({
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent side="right" className="flex w-72 flex-col font-sans">
         <SheetHeader>
-          <SheetTitle className="font-serif text-lg font-light tracking-widest text-primary">
+          <SheetTitle className="font-serif text-lg font-light tracking-widest text-brand">
             Lull
           </SheetTitle>
           <SheetDescription className="sr-only">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,19 +11,19 @@
   --card-foreground: oklch(0.28 0.02 55);
   --popover: oklch(0.96 0.007 85);
   --popover-foreground: oklch(0.28 0.02 55);
-  --primary: oklch(0.55 0.1 45);
+  --primary: oklch(0.30 0.02 55);
   --primary-foreground: oklch(0.965 0.008 85);
   --secondary: oklch(0.92 0.015 80);
   --secondary-foreground: oklch(0.35 0.03 55);
   --muted: oklch(0.93 0.012 80);
   --muted-foreground: oklch(0.5 0.03 55);
-  --accent: oklch(0.65 0.09 65);
-  --accent-foreground: oklch(0.25 0.02 55);
+  --accent: oklch(0.40 0.025 55);
+  --accent-foreground: oklch(0.965 0.008 85);
   --destructive: oklch(0.55 0.15 30);
   --destructive-foreground: oklch(0.96 0.008 85);
   --border: oklch(0.88 0.015 75);
   --input: oklch(0.90 0.012 78);
-  --ring: oklch(0.55 0.1 45);
+  --ring: oklch(0.30 0.02 55);
   --chart-1: oklch(0.55 0.1 45);
   --chart-2: oklch(0.65 0.09 65);
   --chart-3: oklch(0.45 0.05 55);
@@ -32,12 +32,13 @@
   --radius: 0.375rem;
   --sidebar: oklch(0.955 0.008 85);
   --sidebar-foreground: oklch(0.28 0.02 55);
-  --sidebar-primary: oklch(0.55 0.1 45);
+  --sidebar-primary: oklch(0.30 0.02 55);
   --sidebar-primary-foreground: oklch(0.965 0.008 85);
   --sidebar-accent: oklch(0.92 0.015 80);
   --sidebar-accent-foreground: oklch(0.35 0.03 55);
   --sidebar-border: oklch(0.88 0.015 75);
-  --sidebar-ring: oklch(0.55 0.1 45);
+  --sidebar-ring: oklch(0.30 0.02 55);
+  --brand: oklch(0.55 0.1 45);
 }
 
 @theme inline {
@@ -79,6 +80,7 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+  --color-brand: var(--brand);
   --z-header: 50;
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,7 @@ export default async function Page(props: PageProps<"/">) {
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-8">
-      <h1 className="font-serif text-5xl font-light tracking-wide text-primary">
+      <h1 className="font-serif text-5xl font-light tracking-wide text-brand">
         Lull
       </h1>
       <p className="text-sm leading-relaxed text-muted-foreground">


### PR DESCRIPTION
## Summary

- `--primary` を旧 茶 `oklch(0.55 0.1 45)` から **墨色** `oklch(0.30 0.02 55)` に変更し、ボタン・リング・サイドバー要素全体を落ち着いた印象に。
- `--accent` を `oklch(0.40 0.025 55)` の中墨に、`--accent-foreground` を生成り `oklch(0.965 0.008 85)` に反転。**ToggleGroup の active のコントラスト比が約 4:1 → 8:1 に改善**。
- ナビゲーションメニューの active (`bg-accent/40〜50` + `text-foreground`) も実測で **5.35〜6.57:1（WCAG AA pass）** を確認。
- 旧 primary の茶色は `--brand` として新設し、`text-brand` 経由でヘッダー / シート / トップページの "Lull" ロゴが参照。ロゴの色は変更前と同じ。
- `--chart-*` は UI primary とは別軸の暖色グラデーションなので変更せず維持。スプラッシュロゴは元から色ハードコードのため影響なし。

## 変更内容

- `src/app/globals.css` — トークン書き換え + `--brand` / `--color-brand` 追加
- `src/app/_components/app-header.tsx` — ロゴ `text-primary` → `text-brand`
- `src/app/_components/navigation-sheet.tsx` — シートタイトルロゴを `text-brand`
- `src/app/page.tsx` — トップページの "Lull" を `text-brand`

ナビゲーション active 内の `border-primary` / `before:bg-primary/70` は「現在地アクセント線」なので新 primary（墨）を維持。

## Test plan

- [x] `pnpm type-check` PASS
- [x] `pnpm lint` PASS
- [x] Storybook で primary ボタンが墨色で表示されることを確認
- [x] Storybook で "Lull" ロゴが旧色（茶）のままになることを確認 (`app-header--default`)
- [x] navigation `events-new-active` の active 要素のコントラスト比を計測 (5.35:1)
- [ ] 実機の dev server でダッシュボード / イベント管理画面の見た目を最終確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)