### PR TITLE
feat(checkin): チェックイン画面を Concert Hall Lobby コンセプトで刷新

### DIFF
--- a/src/app/(main)/events/[eventId]/checkin/_actions.ts
+++ b/src/app/(main)/events/[eventId]/checkin/_actions.ts
@@ -338,32 +338,38 @@ export async function performBulkCheckIn(
   }
 
   const guestUpdated = !invitation.checkedIn;
-  if (guestUpdated) {
-    await db
-      .update(invitations)
-      .set({ checkedIn: true, checkedInAt: now })
-      .where(
-        and(eq(invitations.id, invitationId), eq(invitations.eventId, eventId)),
-      );
-  }
-
   const companionResults: { id: string; updated: boolean }[] = [];
-  for (const comp of invitation.companions) {
-    if (comp.checkedIn) {
-      companionResults.push({ id: comp.id, updated: false });
-      continue;
+
+  // 本人 + 同伴者の更新は同一トランザクションで（途中失敗時は全ロールバック）
+  await db.transaction(async (tx) => {
+    if (guestUpdated) {
+      await tx
+        .update(invitations)
+        .set({ checkedIn: true, checkedInAt: now })
+        .where(
+          and(
+            eq(invitations.id, invitationId),
+            eq(invitations.eventId, eventId),
+          ),
+        );
     }
-    await db
-      .update(companions)
-      .set({ checkedIn: true, checkedInAt: now })
-      .where(
-        and(
-          eq(companions.id, comp.id),
-          eq(companions.invitationId, invitationId),
-        ),
-      );
-    companionResults.push({ id: comp.id, updated: true });
-  }
+    for (const comp of invitation.companions) {
+      if (comp.checkedIn) {
+        companionResults.push({ id: comp.id, updated: false });
+        continue;
+      }
+      await tx
+        .update(companions)
+        .set({ checkedIn: true, checkedInAt: now })
+        .where(
+          and(
+            eq(companions.id, comp.id),
+            eq(companions.invitationId, invitationId),
+          ),
+        );
+      companionResults.push({ id: comp.id, updated: true });
+    }
+  });
 
   revalidatePath(`/events/${eventId}/checkin`);
   revalidatePath(`/i/${invitation.token}`);

--- a/src/app/(main)/events/[eventId]/checkin/_actions.ts
+++ b/src/app/(main)/events/[eventId]/checkin/_actions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { and, eq, exists, like, or } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { db } from "@/db";
 import { companions, eventMembers, events, invitations } from "@/db/schema";
@@ -24,96 +24,7 @@ export type LookupInvitation = {
   }[];
 };
 
-export type SearchInvitationResult = LookupInvitation & {
-  /** ゲスト名が検索クエリにマッチしたか */
-  guestNameMatched: boolean;
-  /** 検索クエリにマッチした同伴者 id のリスト */
-  matchedCompanionIds: string[];
-};
-
 export type LookupResult = { error: string } | { invitation: LookupInvitation };
-
-/** 名前検索によるチェックイン用招待情報検索 */
-export async function searchInvitationByName(
-  eventId: string,
-  query: string,
-): Promise<{ error: string } | { invitations: SearchInvitationResult[] }> {
-  const session = await requireSession();
-
-  // メンバー権限チェック
-  const member = await db.query.eventMembers.findFirst({
-    where: and(
-      eq(eventMembers.eventId, eventId),
-      eq(eventMembers.userId, session.user.id),
-    ),
-  });
-  if (!member) return { error: "権限がありません" };
-
-  // イベントステータスチェック（ongoing のみ）
-  const event = await db.query.events.findFirst({
-    where: eq(events.id, eventId),
-  });
-  if (!event || event.status !== "ongoing") {
-    return { error: "チェックインは開催中のイベントでのみ利用できます" };
-  }
-
-  const trimmed = query.trim();
-  if (!trimmed) return { invitations: [] };
-
-  // DB 側で guestName / 同伴者名の LIKE 検索
-  const pattern = `%${trimmed}%`;
-  const rows = await db.query.invitations.findMany({
-    where: and(
-      eq(invitations.eventId, eventId),
-      eq(invitations.status, "accepted"),
-      or(
-        like(invitations.guestName, pattern),
-        exists(
-          db
-            .select({ id: companions.id })
-            .from(companions)
-            .where(
-              and(
-                eq(companions.invitationId, invitations.id),
-                like(companions.name, pattern),
-              ),
-            ),
-        ),
-      ),
-    ),
-    with: {
-      companions: {
-        columns: {
-          id: true,
-          name: true,
-          checkedIn: true,
-          checkedInAt: true,
-        },
-      },
-    },
-  });
-
-  const lower = trimmed.toLowerCase();
-  return {
-    invitations: rows.map((r) => {
-      const guestNameMatched =
-        r.guestName?.toLowerCase().includes(lower) ?? false;
-      const matchedCompanionIds = r.companions
-        .filter((c) => c.name.toLowerCase().includes(lower))
-        .map((c) => c.id);
-      return {
-        id: r.id,
-        guestName: r.guestName,
-        guestEmail: r.guestEmail,
-        checkedIn: r.checkedIn,
-        checkedInAt: r.checkedInAt,
-        companions: r.companions,
-        guestNameMatched,
-        matchedCompanionIds,
-      };
-    }),
-  };
-}
 
 /** QR コード読み取り後、トークンから招待情報を検索 */
 export async function lookupInvitationByToken(
@@ -372,4 +283,95 @@ export async function undoCheckIn(
   revalidatePath(`/i/${inv.token}`);
 
   return { summary: await getCheckInSummary(eventId) };
+}
+
+export type BulkCheckInResult =
+  | { error: string }
+  | {
+      summary: CheckInSummary;
+      checkedInAt: number;
+      guest: { updated: boolean };
+      companions: { id: string; updated: boolean }[];
+    };
+
+/** 招待単位で本人 + 全同伴者の未チェックインをまとめて更新 */
+export async function performBulkCheckIn(
+  eventId: string,
+  invitationId: string,
+): Promise<BulkCheckInResult> {
+  const session = await requireSession();
+
+  const member = await db.query.eventMembers.findFirst({
+    where: and(
+      eq(eventMembers.eventId, eventId),
+      eq(eventMembers.userId, session.user.id),
+    ),
+  });
+  if (!member) return { error: "権限がありません" };
+
+  const event = await db.query.events.findFirst({
+    where: eq(events.id, eventId),
+  });
+  if (!event || event.status !== "ongoing") {
+    return { error: "チェックインは開催中のイベントでのみ利用できます" };
+  }
+
+  const now = Date.now();
+
+  const invitation = await db.query.invitations.findFirst({
+    where: and(
+      eq(invitations.id, invitationId),
+      eq(invitations.eventId, eventId),
+    ),
+    with: {
+      companions: {
+        columns: { id: true, checkedIn: true },
+      },
+    },
+  });
+  if (!invitation) return { error: "招待が見つかりません" };
+  if (invitation.status !== "accepted") {
+    return { error: "出席が確定していない招待にはチェックインできません" };
+  }
+  if (invitation.invalidatedAt) {
+    return { error: "この招待は無効化されています" };
+  }
+
+  const guestUpdated = !invitation.checkedIn;
+  if (guestUpdated) {
+    await db
+      .update(invitations)
+      .set({ checkedIn: true, checkedInAt: now })
+      .where(
+        and(eq(invitations.id, invitationId), eq(invitations.eventId, eventId)),
+      );
+  }
+
+  const companionResults: { id: string; updated: boolean }[] = [];
+  for (const comp of invitation.companions) {
+    if (comp.checkedIn) {
+      companionResults.push({ id: comp.id, updated: false });
+      continue;
+    }
+    await db
+      .update(companions)
+      .set({ checkedIn: true, checkedInAt: now })
+      .where(
+        and(
+          eq(companions.id, comp.id),
+          eq(companions.invitationId, invitationId),
+        ),
+      );
+    companionResults.push({ id: comp.id, updated: true });
+  }
+
+  revalidatePath(`/events/${eventId}/checkin`);
+  revalidatePath(`/i/${invitation.token}`);
+
+  return {
+    summary: await getCheckInSummary(eventId),
+    checkedInAt: now,
+    guest: { updated: guestUpdated },
+    companions: companionResults,
+  };
 }

--- a/src/app/(main)/events/[eventId]/checkin/page.tsx
+++ b/src/app/(main)/events/[eventId]/checkin/page.tsx
@@ -25,9 +25,9 @@ export default async function CheckInPage(
   const checkInList = await getCheckInList(eventId);
 
   return (
-    <div className="mx-auto max-w-4xl px-6 py-12">
+    <>
       <HeaderConfig showBackButton />
       <CheckInView event={event} summary={summary} initialList={checkInList} />
-    </div>
+    </>
   );
 }

--- a/src/app/_components/check-in-view.tsx
+++ b/src/app/_components/check-in-view.tsx
@@ -1,33 +1,26 @@
 "use client";
 
 import {
-  CaretDown,
-  CaretUp,
   CheckCircle,
   Circle,
+  MagnifyingGlass,
   QrCode,
   Spinner,
-  User,
-  Users,
   Warning,
+  X,
 } from "@phosphor-icons/react";
-import { useCallback, useState } from "react";
+import { animate, motion, useMotionValue, useTransform } from "motion/react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   type LookupInvitation,
   lookupInvitationByToken,
+  performBulkCheckIn,
   performCheckIn,
-  type SearchInvitationResult,
-  searchInvitationByName,
   undoCheckIn,
 } from "@/app/(main)/events/[eventId]/checkin/_actions";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
+import { Card, CardContent } from "@/components/ui/card";
 import {
   Dialog,
   DialogContent,
@@ -35,6 +28,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import type { EventStatus } from "@/db/schema";
 import { statusLabels, statusVariants } from "@/lib/event-status";
 import type {
@@ -54,34 +48,20 @@ type CheckInViewProps = {
   initialList: CheckInListItem[];
 };
 
-/**
- * 結果の表示先。
- * - popup: QR スキャン / 名前検索で選択したアイテム / 一覧からの選択など、
- *   ユーザーが特定のゲストを指定したケースは Dialog で表示する（切り替わりに
- *   気づけるようカメラ時と同じ体験に統一）。
- * - inline: ページ下部にそのまま出す。カメラ起動・検索時のエラーなど、
- *   特定ゲストに紐づかない状態の通知に使用する。
- */
-type ResultSource = "popup" | "inline";
-
 type ViewState =
   | { mode: "idle" }
   | { mode: "scanning" }
-  | { mode: "loading"; source: ResultSource }
-  | { mode: "error"; message: string; source: ResultSource }
-  | {
-      mode: "found";
-      invitation: LookupInvitation;
-      source: ResultSource;
-    };
+  | { mode: "loading" }
+  | { mode: "error"; message: string }
+  | { mode: "found"; invitation: LookupInvitation };
 
-/** スキャン結果の URL からトークンを抽出 */
+type RosterFilter = "pending" | "done";
+
 function extractToken(scannedValue: string): string | null {
   const match = scannedValue.match(/\/i\/([A-Za-z0-9_-]+)/);
   return match ? match[1] : null;
 }
 
-/** タイムスタンプを JST の HH:mm 形式にフォーマット */
 function formatTimestamp(ts: number): string {
   return new Intl.DateTimeFormat("ja-JP", {
     hour: "2-digit",
@@ -89,6 +69,16 @@ function formatTimestamp(ts: number): string {
     hour12: false,
     timeZone: "Asia/Tokyo",
   }).format(new Date(ts));
+}
+
+function vibrate(pattern: number | number[]) {
+  if (typeof navigator !== "undefined" && "vibrate" in navigator) {
+    try {
+      navigator.vibrate(pattern);
+    } catch {
+      // ignore
+    }
+  }
 }
 
 export function CheckInView({
@@ -102,10 +92,36 @@ export function CheckInView({
     useState<CheckInListItem[]>(initialList);
   const [scanKey, setScanKey] = useState(0);
   const [processing, setProcessing] = useState<string | null>(null);
-  const [listOpen, setListOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
-  const [searching, setSearching] = useState(false);
+  const [rosterFilter, setRosterFilter] = useState<RosterFilter>("pending");
   const [isRequestingCamera, setIsRequestingCamera] = useState(false);
+
+  const updateListAfterCheckIn = useCallback(
+    (
+      invitationId: string,
+      targetType: "guest" | "companion",
+      targetId: string | undefined,
+      checkedIn: boolean,
+      checkedInAt?: number | null,
+    ) => {
+      const ts = checkedIn ? (checkedInAt ?? null) : null;
+      setCheckInList((prev) =>
+        prev.map((item) => {
+          if (item.id !== invitationId) return item;
+          if (targetType === "guest") {
+            return { ...item, checkedIn, checkedInAt: ts };
+          }
+          return {
+            ...item,
+            companions: item.companions.map((c) =>
+              c.id === targetId ? { ...c, checkedIn, checkedInAt: ts } : c,
+            ),
+          };
+        }),
+      );
+    },
+    [],
+  );
 
   const handleScan = useCallback(
     async (decodedText: string) => {
@@ -114,59 +130,19 @@ export function CheckInView({
         setViewState({
           mode: "error",
           message: "QR コードからトークンを読み取れませんでした",
-          source: "popup",
         });
         return;
       }
-
-      setViewState({ mode: "loading", source: "popup" });
-
+      setViewState({ mode: "loading" });
       const result = await lookupInvitationByToken(event.id, token);
       if ("error" in result) {
-        setViewState({
-          mode: "error",
-          message: result.error,
-          source: "popup",
-        });
+        setViewState({ mode: "error", message: result.error });
       } else {
-        setViewState({
-          mode: "found",
-          invitation: result.invitation,
-          source: "popup",
-        });
+        setViewState({ mode: "found", invitation: result.invitation });
       }
     },
     [event.id],
   );
-
-  /** チェックイン後にローカルリストを更新 */
-  const updateListAfterCheckIn = (
-    invitationId: string,
-    targetType: "guest" | "companion",
-    targetId: string | undefined,
-    checkedIn: boolean,
-    checkedInAt?: number | null,
-  ) => {
-    const ts = checkedIn ? (checkedInAt ?? null) : null;
-    setCheckInList((prev) =>
-      prev.map((item) => {
-        if (item.id !== invitationId) return item;
-        if (targetType === "guest") {
-          return {
-            ...item,
-            checkedIn,
-            checkedInAt: ts,
-          };
-        }
-        return {
-          ...item,
-          companions: item.companions.map((c) =>
-            c.id === targetId ? { ...c, checkedIn, checkedInAt: ts } : c,
-          ),
-        };
-      }),
-    );
-  };
 
   const handleCheckIn = async (
     invitationId: string,
@@ -182,19 +158,11 @@ export function CheckInView({
         targetType,
         targetId,
       );
-
-      const currentSource: ResultSource =
-        viewState.mode === "found" ? viewState.source : "inline";
-
       if ("error" in result) {
-        setViewState({
-          mode: "error",
-          message: result.error,
-          source: currentSource,
-        });
+        setViewState({ mode: "error", message: result.error });
+        vibrate([20, 50, 20]);
         return;
       }
-
       const serverTime = result.checkedInAt;
       setSummary(result.summary);
       updateListAfterCheckIn(
@@ -204,8 +172,7 @@ export function CheckInView({
         true,
         serverTime,
       );
-
-      // 確認パネル内の招待情報を更新
+      vibrate(10);
       if (viewState.mode === "found") {
         const updated = { ...viewState.invitation };
         if (targetType === "guest") {
@@ -218,19 +185,12 @@ export function CheckInView({
               : c,
           );
         }
-        setViewState({
-          mode: "found",
-          invitation: updated,
-          source: viewState.source,
-        });
+        setViewState({ mode: "found", invitation: updated });
       }
     } catch {
-      const currentSource: ResultSource =
-        viewState.mode === "found" ? viewState.source : "inline";
       setViewState({
         mode: "error",
         message: "チェックイン処理中にエラーが発生しました",
-        source: currentSource,
       });
     } finally {
       setProcessing(null);
@@ -251,22 +211,12 @@ export function CheckInView({
         targetType,
         targetId,
       );
-
-      const currentSource: ResultSource =
-        viewState.mode === "found" ? viewState.source : "inline";
-
       if ("error" in result) {
-        setViewState({
-          mode: "error",
-          message: result.error,
-          source: currentSource,
-        });
+        setViewState({ mode: "error", message: result.error });
         return;
       }
-
       setSummary(result.summary);
       updateListAfterCheckIn(invitationId, targetType, targetId, false);
-
       if (viewState.mode === "found") {
         const updated = { ...viewState.invitation };
         if (targetType === "guest") {
@@ -279,19 +229,53 @@ export function CheckInView({
               : c,
           );
         }
-        setViewState({
-          mode: "found",
-          invitation: updated,
-          source: viewState.source,
-        });
+        setViewState({ mode: "found", invitation: updated });
       }
     } catch {
-      const currentSource: ResultSource =
-        viewState.mode === "found" ? viewState.source : "inline";
       setViewState({
         mode: "error",
         message: "取り消し処理中にエラーが発生しました",
-        source: currentSource,
+      });
+    } finally {
+      setProcessing(null);
+    }
+  };
+
+  const handleBulkCheckIn = async (invitationId: string) => {
+    setProcessing("bulk");
+    try {
+      const result = await performBulkCheckIn(event.id, invitationId);
+      if ("error" in result) {
+        setViewState({ mode: "error", message: result.error });
+        vibrate([20, 50, 20]);
+        return;
+      }
+      setSummary(result.summary);
+      const ts = result.checkedInAt;
+      if (result.guest.updated) {
+        updateListAfterCheckIn(invitationId, "guest", undefined, true, ts);
+      }
+      for (const c of result.companions) {
+        if (c.updated) {
+          updateListAfterCheckIn(invitationId, "companion", c.id, true, ts);
+        }
+      }
+      vibrate(10);
+      if (viewState.mode === "found") {
+        const updated = { ...viewState.invitation };
+        updated.checkedIn = true;
+        updated.checkedInAt = ts;
+        updated.companions = updated.companions.map((c) => ({
+          ...c,
+          checkedIn: true,
+          checkedInAt: c.checkedIn ? c.checkedInAt : ts,
+        }));
+        setViewState({ mode: "found", invitation: updated });
+      }
+    } catch {
+      setViewState({
+        mode: "error",
+        message: "一括チェックイン処理中にエラーが発生しました",
       });
     } finally {
       setProcessing(null);
@@ -299,10 +283,7 @@ export function CheckInView({
   };
 
   const startScanning = async () => {
-    // 権限ダイアログ表示中の連打で getUserMedia が多重実行されるのを防ぐ
     if (isRequestingCamera) return;
-    // PWA / iOS Safari で権限ダイアログを確実に出すため、
-    // ユーザー操作のコールスタックから直接 getUserMedia を呼ぶ
     if (
       typeof navigator === "undefined" ||
       !navigator.mediaDevices?.getUserMedia
@@ -310,7 +291,6 @@ export function CheckInView({
       setViewState({
         mode: "error",
         message: "お使いのブラウザはカメラ機能に対応していません",
-        source: "inline",
       });
       return;
     }
@@ -320,7 +300,6 @@ export function CheckInView({
         video: { facingMode: "environment" },
         audio: false,
       });
-      // html5-qrcode 側で再度 getUserMedia が呼ばれるので、ここでは停止
       for (const track of stream.getTracks()) {
         track.stop();
       }
@@ -336,7 +315,6 @@ export function CheckInView({
           : err instanceof Error
             ? err.message
             : "カメラの起動に失敗しました",
-        source: "inline",
       });
       return;
     } finally {
@@ -346,27 +324,6 @@ export function CheckInView({
     setViewState({ mode: "scanning" });
   };
 
-  const [searchResults, setSearchResults] = useState<
-    SearchInvitationResult[] | null
-  >(null);
-
-  const handleSearch = async () => {
-    if (!searchQuery.trim()) return;
-    setSearching(true);
-    const result = await searchInvitationByName(event.id, searchQuery);
-    setSearching(false);
-    if ("error" in result) {
-      setViewState({
-        mode: "error",
-        message: result.error,
-        source: "inline",
-      });
-    } else {
-      setSearchResults(result.invitations);
-    }
-  };
-
-  /** リスト行タップで found モードに遷移 */
   const selectFromList = (item: CheckInListItem) => {
     setViewState({
       mode: "found",
@@ -378,14 +335,71 @@ export function CheckInView({
         checkedInAt: item.checkedInAt,
         companions: item.companions,
       },
-      source: "popup",
     });
   };
+
+  // 名前フィルタ + ステータスフィルタ
+  const filteredList = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    const isDoneFilter = rosterFilter === "done";
+    return checkInList
+      .map((item) => {
+        const guestNameMatched =
+          q === "" || (item.guestName?.toLowerCase().includes(q) ?? false);
+        const matchedCompanions = item.companions.filter(
+          (c) => q === "" || c.name.toLowerCase().includes(q),
+        );
+        return { item, guestNameMatched, matchedCompanions };
+      })
+      .filter(
+        ({ guestNameMatched, matchedCompanions }) =>
+          guestNameMatched || matchedCompanions.length > 0,
+      )
+      .map(({ item, guestNameMatched, matchedCompanions }) => {
+        // 表示する子行: クエリありなら matchedCompanions、なしなら全員
+        const displayCompanions =
+          q === "" ? item.companions : matchedCompanions;
+        return { item, guestNameMatched, displayCompanions };
+      })
+      .filter(({ item, displayCompanions }) => {
+        // 未来場 / 来場済 切替
+        if (isDoneFilter) {
+          return item.checkedIn || displayCompanions.some((c) => c.checkedIn);
+        }
+        return !item.checkedIn || displayCompanions.some((c) => !c.checkedIn);
+      });
+  }, [checkInList, searchQuery, rosterFilter]);
+
+  const pendingCount = useMemo(
+    () =>
+      checkInList.reduce(
+        (sum, i) =>
+          sum +
+          (i.checkedIn ? 0 : 1) +
+          i.companions.filter((c) => !c.checkedIn).length,
+        0,
+      ),
+    [checkInList],
+  );
+  const doneCount = useMemo(
+    () =>
+      checkInList.reduce(
+        (sum, i) =>
+          sum +
+          (i.checkedIn ? 1 : 0) +
+          i.companions.filter((c) => c.checkedIn).length,
+        0,
+      ),
+    [checkInList],
+  );
+
+  const totalArrived = summary.checkedInGuests + summary.checkedInCompanions;
+  const totalExpected = summary.totalAccepted + summary.totalCompanions;
 
   // ongoing 以外はメッセージのみ表示
   if (event.status !== "ongoing") {
     return (
-      <div className="space-y-6">
+      <div className="mx-auto max-w-md px-4 py-12">
         <div>
           <h1 className="text-3xl font-light tracking-wide">チェックイン</h1>
           <div className="mt-2 flex items-center gap-3">
@@ -395,7 +409,7 @@ export function CheckInView({
             </Badge>
           </div>
         </div>
-        <Card>
+        <Card className="mt-6">
           <CardContent className="pt-6">
             <p className="text-muted-foreground text-center">
               チェックインは開催中のイベントでのみ利用できます
@@ -407,304 +421,385 @@ export function CheckInView({
   }
 
   return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-light tracking-wide">チェックイン</h1>
-        <div className="mt-2 flex items-center gap-3">
-          <span className="text-muted-foreground">{event.name}</span>
-          <Badge variant={statusVariants[event.status]}>
+    <div className="mx-auto max-w-md px-4 pb-32">
+      {/* Sticky top: イベント名 + ステータス */}
+      <div className="bg-background/80 supports-[backdrop-filter]:bg-background/60 sticky top-0 z-10 -mx-4 mb-2 border-b px-4 py-3 backdrop-blur-md">
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <div className="text-muted-foreground text-[10px] font-medium tracking-[0.2em] uppercase">
+              Event
+            </div>
+            <div className="truncate text-base font-medium">{event.name}</div>
+          </div>
+          <Badge variant={statusVariants[event.status]} className="shrink-0">
             {statusLabels[event.status]}
           </Badge>
         </div>
       </div>
 
-      {/* QR スキャンボタン（上部に常設） */}
-      {viewState.mode !== "scanning" ? (
-        <Button
-          onClick={startScanning}
-          size="lg"
-          className="w-full gap-2"
-          disabled={isRequestingCamera}
-        >
-          <QrCode className="size-5" />
-          {isRequestingCamera ? "カメラを起動中..." : "QR スキャン"}
-        </Button>
+      {viewState.mode === "scanning" ? (
+        <ScanningView
+          scanKey={scanKey}
+          onScan={handleScan}
+          onCancel={() => setViewState({ mode: "idle" })}
+        />
       ) : (
-        <div className="space-y-4">
-          <QrScanner key={scanKey} onScan={handleScan} />
-          <div className="flex justify-center">
-            <Button
-              variant="outline"
-              onClick={() => setViewState({ mode: "idle" })}
-            >
-              キャンセル
-            </Button>
-          </div>
+        <>
+          <ArrivalsHero
+            arrived={totalArrived}
+            expected={totalExpected}
+            checkedInGuests={summary.checkedInGuests}
+            checkedInCompanions={summary.checkedInCompanions}
+          />
+          <RosterSection
+            filteredList={filteredList}
+            pendingCount={pendingCount}
+            doneCount={doneCount}
+            searchQuery={searchQuery}
+            onSearchChange={setSearchQuery}
+            rosterFilter={rosterFilter}
+            onFilterChange={setRosterFilter}
+            onSelect={selectFromList}
+          />
+        </>
+      )}
+
+      {/* Sticky bottom CTA */}
+      {viewState.mode !== "scanning" && (
+        <div
+          className="from-background/0 via-background/85 to-background/95 fixed inset-x-0 bottom-0 z-20 mx-auto max-w-md bg-gradient-to-b px-4 pt-3 backdrop-blur-md"
+          style={{ paddingBottom: "calc(env(safe-area-inset-bottom) + 16px)" }}
+        >
+          <Button
+            onClick={startScanning}
+            disabled={isRequestingCamera}
+            className="h-14 w-full gap-2 text-base"
+          >
+            <QrCode className="size-5" />
+            {isRequestingCamera ? "カメラを起動中..." : "QR スキャン"}
+          </Button>
         </div>
       )}
 
-      {/* 名前検索フォーム（常設） */}
-      {viewState.mode !== "scanning" && (
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">名前で検索</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="flex gap-2">
-              <Input
-                placeholder="ゲスト名・同伴者名を入力"
-                value={searchQuery}
-                onChange={(e) => {
-                  setSearchQuery(e.target.value);
-                  if (!e.target.value.trim()) setSearchResults(null);
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    handleSearch();
-                  }
-                }}
-              />
-              <Button
-                onClick={handleSearch}
-                disabled={searching || !searchQuery.trim()}
-                className="shrink-0"
-              >
-                {searching ? (
-                  <Spinner className="size-4 animate-spin" />
-                ) : (
-                  "検索"
-                )}
-              </Button>
-            </div>
-
-            {searchResults !== null && searchResults.length === 0 && (
-              <p className="text-muted-foreground text-sm text-center py-2">
-                該当するゲストが見つかりません
-              </p>
-            )}
-
-            {searchResults && searchResults.length > 0 && (
-              <div className="space-y-1">
-                {searchResults.map((inv) => {
-                  const matchedCompanionNames = inv.companions
-                    .filter((c) => inv.matchedCompanionIds.includes(c.id))
-                    .map((c) => c.name);
-                  return (
-                    <button
-                      key={inv.id}
-                      type="button"
-                      className="flex w-full items-start gap-2 rounded-md px-3 py-3 hover:bg-muted/50 transition-colors border"
-                      onClick={() =>
-                        setViewState({
-                          mode: "found",
-                          invitation: {
-                            id: inv.id,
-                            guestName: inv.guestName,
-                            guestEmail: inv.guestEmail,
-                            checkedIn: inv.checkedIn,
-                            checkedInAt: inv.checkedInAt,
-                            companions: inv.companions,
-                          },
-                          source: "popup",
-                        })
-                      }
-                    >
-                      {inv.checkedIn ? (
-                        <CheckCircle
-                          className="size-4 shrink-0 mt-0.5 text-emerald-800/70"
-                          weight="fill"
-                        />
-                      ) : (
-                        <Circle className="size-4 shrink-0 mt-0.5 text-muted-foreground" />
-                      )}
-                      <div className="flex-1 text-left">
-                        <div className="text-sm">
-                          {inv.guestName ?? "名前未登録"}
-                          {inv.companions.length > 0 && (
-                            <span className="text-muted-foreground text-xs ml-2">
-                              +{inv.companions.length}名
-                            </span>
-                          )}
-                        </div>
-                        {matchedCompanionNames.length > 0 && (
-                          <div className="text-muted-foreground text-xs mt-0.5">
-                            同伴者: {matchedCompanionNames.join("、")}
-                          </div>
-                        )}
-                      </div>
-                    </button>
-                  );
-                })}
-              </div>
-            )}
-          </CardContent>
-        </Card>
-      )}
-
-      {/* サマリーカード：チェックイン済み / 出席予定 合計 */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">来場者数</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="flex items-baseline gap-2">
-            <Users className="text-muted-foreground size-5 self-center" />
-            <span className="text-2xl font-light tabular-nums">
-              {summary.checkedInGuests + summary.checkedInCompanions}
-            </span>
-            <span className="text-muted-foreground text-sm">/</span>
-            <span className="text-muted-foreground tabular-nums">
-              {summary.totalAccepted + summary.totalCompanions}
-            </span>
-            <span className="text-muted-foreground text-xs ml-1">
-              名がチェックイン済み
-            </span>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* 来場者一覧（Collapsible） */}
-      <Collapsible open={listOpen} onOpenChange={setListOpen}>
-        <Card>
-          <CollapsibleTrigger asChild>
-            <button
-              type="button"
-              className="flex w-full items-center justify-between px-6 py-4"
-            >
-              <span className="text-base font-semibold">来場者一覧</span>
-              {listOpen ? (
-                <CaretUp className="size-5 text-muted-foreground" />
-              ) : (
-                <CaretDown className="size-5 text-muted-foreground" />
-              )}
-            </button>
-          </CollapsibleTrigger>
-          <CollapsibleContent>
-            <CardContent className="space-y-1 pt-0">
-              {checkInList.length === 0 && (
-                <p className="text-muted-foreground text-sm py-2">
-                  出席予定のゲストがいません
-                </p>
-              )}
-              {checkInList.map((item) => (
-                <div key={item.id}>
-                  <button
-                    type="button"
-                    className="flex w-full items-center gap-2 rounded-md px-2 py-2 hover:bg-muted/50 transition-colors"
-                    onClick={() => selectFromList(item)}
-                  >
-                    {item.checkedIn ? (
-                      <CheckCircle
-                        className="size-4 shrink-0 text-emerald-800/70"
-                        weight="fill"
-                      />
-                    ) : (
-                      <Circle className="size-4 shrink-0 text-muted-foreground" />
-                    )}
-                    <span className="text-sm flex-1 text-left">
-                      {item.guestName ?? "名前未登録"}
-                    </span>
-                    {item.checkedIn && item.checkedInAt && (
-                      <span className="text-muted-foreground text-xs">
-                        {formatTimestamp(item.checkedInAt)}
-                      </span>
-                    )}
-                  </button>
-                  {item.companions.map((c) => (
-                    <button
-                      key={c.id}
-                      type="button"
-                      className="flex w-full items-center gap-2 rounded-md pl-6 pr-2 py-2 hover:bg-muted/50 transition-colors"
-                      onClick={() => selectFromList(item)}
-                    >
-                      {c.checkedIn ? (
-                        <CheckCircle
-                          className="size-4 shrink-0 text-emerald-800/70"
-                          weight="fill"
-                        />
-                      ) : (
-                        <Circle className="size-4 shrink-0 text-muted-foreground" />
-                      )}
-                      <span className="text-sm flex-1 text-left">{c.name}</span>
-                      {c.checkedIn && c.checkedInAt && (
-                        <span className="text-muted-foreground text-xs">
-                          {formatTimestamp(c.checkedInAt)}
-                        </span>
-                      )}
-                    </button>
-                  ))}
-                </div>
-              ))}
-            </CardContent>
-          </CollapsibleContent>
-        </Card>
-      </Collapsible>
-
-      {/* インライン（名前検索・一覧選択）からの結果表示 */}
-      {(viewState.mode === "loading" ||
-        viewState.mode === "error" ||
-        viewState.mode === "found") &&
-        viewState.source === "inline" && (
-          <ResultPanel
-            viewState={viewState}
-            processing={processing}
-            onCheckIn={handleCheckIn}
-            onUndo={handleUndo}
-            onRescan={startScanning}
-          />
-        )}
-
-      {/* QR スキャン結果はポップアップで表示 */}
+      {/* Dialog: スキャン結果 / 一覧選択結果 / loading / error */}
       <Dialog
         open={
-          (viewState.mode === "loading" ||
-            viewState.mode === "error" ||
-            viewState.mode === "found") &&
-          viewState.source === "popup"
+          viewState.mode === "loading" ||
+          viewState.mode === "error" ||
+          viewState.mode === "found"
         }
         onOpenChange={(open) => {
           if (!open) setViewState({ mode: "idle" });
         }}
       >
-        <DialogContent className="max-w-md max-h-[calc(100dvh-2rem)] overflow-y-auto">
+        <DialogContent className="max-h-[calc(100dvh-2rem)] max-w-md overflow-y-auto">
           <DialogHeader>
-            <DialogTitle>
+            <div className="text-muted-foreground text-[10px] font-medium tracking-[0.2em] uppercase">
+              {viewState.mode === "error" ? "Error" : "Guest"}
+            </div>
+            <DialogTitle className="text-2xl font-light tracking-tight">
               {viewState.mode === "found"
                 ? (viewState.invitation.guestName ?? "名前未登録")
                 : viewState.mode === "error"
-                  ? "QR スキャンエラー"
+                  ? "照会エラー"
                   : "照会中"}
             </DialogTitle>
           </DialogHeader>
-          {(viewState.mode === "loading" ||
-            viewState.mode === "error" ||
-            viewState.mode === "found") &&
-            viewState.source === "popup" && (
-              <ResultPanel
-                viewState={viewState}
-                processing={processing}
-                onCheckIn={handleCheckIn}
-                onUndo={handleUndo}
-                onRescan={startScanning}
-                variant="dialog"
-              />
-            )}
+          {viewState.mode === "loading" && (
+            <div className="flex flex-col items-center gap-2 py-10">
+              <Spinner className="size-8 animate-spin" />
+              <p className="text-muted-foreground text-sm">照会中...</p>
+            </div>
+          )}
+          {viewState.mode === "error" && (
+            <div className="space-y-4 pt-2">
+              <div className="border-destructive bg-destructive/5 flex items-start gap-3 rounded-md border-l-2 px-3 py-3">
+                <Warning className="text-destructive mt-0.5 size-5 shrink-0" />
+                <p className="text-destructive text-sm">{viewState.message}</p>
+              </div>
+              <div className="flex justify-end">
+                <Button variant="outline" onClick={startScanning}>
+                  再スキャン
+                </Button>
+              </div>
+            </div>
+          )}
+          {viewState.mode === "found" && (
+            <FoundPanel
+              invitation={viewState.invitation}
+              processing={processing}
+              onCheckIn={handleCheckIn}
+              onUndo={handleUndo}
+              onBulk={handleBulkCheckIn}
+              onClose={() => setViewState({ mode: "idle" })}
+              onRescan={startScanning}
+            />
+          )}
         </DialogContent>
       </Dialog>
     </div>
   );
 }
 
-type ResultPanelProps = {
-  viewState:
-    | { mode: "loading"; source: ResultSource }
-    | { mode: "error"; message: string; source: ResultSource }
-    | {
-        mode: "found";
-        invitation: LookupInvitation;
-        source: ResultSource;
-      };
+// ============================================================
+// Sub: ArrivalsHero
+// ============================================================
+
+type ArrivalsHeroProps = {
+  arrived: number;
+  expected: number;
+  checkedInGuests: number;
+  checkedInCompanions: number;
+};
+
+function ArrivalsHero({
+  arrived,
+  expected,
+  checkedInGuests,
+  checkedInCompanions,
+}: ArrivalsHeroProps) {
+  const arrivedMv = useMotionValue(arrived);
+  const arrivedDisplay = useTransform(arrivedMv, (v) => Math.round(v));
+  const prevArrived = useRef(arrived);
+
+  useEffect(() => {
+    const controls = animate(arrivedMv, arrived, {
+      duration: prevArrived.current === arrived ? 0 : 0.8,
+      ease: "easeOut",
+    });
+    prevArrived.current = arrived;
+    return () => controls.stop();
+  }, [arrived, arrivedMv]);
+
+  const ratio = expected === 0 ? 0 : Math.min(arrived / expected, 1);
+  const radius = 42;
+  const circumference = 2 * Math.PI * radius;
+  const dashOffset = circumference * (1 - ratio);
+  const remaining = Math.max(expected - arrived, 0);
+
+  return (
+    <section className="px-1 pt-6 pb-8">
+      <div className="text-muted-foreground mb-5 text-[10px] font-medium tracking-[0.28em] uppercase">
+        Arrivals
+      </div>
+      <div className="flex items-end gap-5">
+        <div className="relative size-24 shrink-0">
+          <svg
+            viewBox="0 0 100 100"
+            className="size-full -rotate-90"
+            role="img"
+            aria-label={`チェックイン進捗 ${expected === 0 ? 0 : Math.round(ratio * 100)}%`}
+          >
+            <title>{`チェックイン進捗 ${expected === 0 ? 0 : Math.round(ratio * 100)}%`}</title>
+            <circle
+              cx="50"
+              cy="50"
+              r={radius}
+              fill="none"
+              strokeWidth="6"
+              className="stroke-border"
+            />
+            <circle
+              cx="50"
+              cy="50"
+              r={radius}
+              fill="none"
+              strokeWidth="6"
+              strokeLinecap="round"
+              strokeDasharray={circumference}
+              strokeDashoffset={dashOffset}
+              className="stroke-emerald-700/70 transition-[stroke-dashoffset] duration-700 ease-out"
+            />
+          </svg>
+          <div className="text-muted-foreground absolute inset-0 flex items-center justify-center text-xs tabular-nums">
+            {expected === 0 ? "—" : `${Math.round(ratio * 100)}%`}
+          </div>
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-baseline gap-2">
+            <motion.span className="text-6xl font-light tabular-nums tracking-tight">
+              {arrivedDisplay}
+            </motion.span>
+            <span className="text-muted-foreground/60 text-2xl font-thin">
+              /
+            </span>
+            <span className="text-muted-foreground text-2xl font-light tabular-nums">
+              {expected}
+            </span>
+          </div>
+          <div className="text-muted-foreground mt-1 text-xs tabular-nums">
+            本人 {checkedInGuests} · 同伴 {checkedInCompanions} · 残 {remaining}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ============================================================
+// Sub: RosterSection
+// ============================================================
+
+type RosterSectionProps = {
+  filteredList: {
+    item: CheckInListItem;
+    guestNameMatched: boolean;
+    displayCompanions: CheckInListItem["companions"];
+  }[];
+  pendingCount: number;
+  doneCount: number;
+  searchQuery: string;
+  onSearchChange: (q: string) => void;
+  rosterFilter: RosterFilter;
+  onFilterChange: (f: RosterFilter) => void;
+  onSelect: (item: CheckInListItem) => void;
+};
+
+function RosterSection({
+  filteredList,
+  pendingCount,
+  doneCount,
+  searchQuery,
+  onSearchChange,
+  rosterFilter,
+  onFilterChange,
+  onSelect,
+}: RosterSectionProps) {
+  return (
+    <section className="space-y-3 px-1">
+      <div className="flex items-center justify-between gap-3">
+        <div className="text-muted-foreground text-[10px] font-medium tracking-[0.28em] uppercase">
+          Roster
+        </div>
+        <ToggleGroup
+          type="single"
+          size="sm"
+          value={rosterFilter}
+          onValueChange={(v) => {
+            if (v === "pending" || v === "done") onFilterChange(v);
+          }}
+        >
+          <ToggleGroupItem value="pending" className="text-xs">
+            未来場 {pendingCount}
+          </ToggleGroupItem>
+          <ToggleGroupItem value="done" className="text-xs">
+            来場済 {doneCount}
+          </ToggleGroupItem>
+        </ToggleGroup>
+      </div>
+
+      <div className="relative">
+        <MagnifyingGlass className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+        <Input
+          placeholder="名前で絞り込み"
+          value={searchQuery}
+          onChange={(e) => onSearchChange(e.target.value)}
+          className="pl-9"
+        />
+      </div>
+
+      <ul className="divide-border/60 divide-y border-y">
+        {filteredList.length === 0 && (
+          <li className="text-muted-foreground py-6 text-center text-sm">
+            {searchQuery
+              ? "該当するゲストが見つかりません"
+              : rosterFilter === "pending"
+                ? "未来場のゲストはいません"
+                : "来場済のゲストはまだいません"}
+          </li>
+        )}
+        {filteredList.map(({ item, displayCompanions }) => {
+          const totalCompanions = item.companions.length;
+          return (
+            <li key={item.id}>
+              <button
+                type="button"
+                onClick={() => onSelect(item)}
+                className="hover:bg-muted/40 flex w-full items-center gap-3 px-1 py-3 text-left transition-colors"
+              >
+                {item.checkedIn ? (
+                  <CheckCircle
+                    className="size-4 shrink-0 text-emerald-700"
+                    weight="fill"
+                  />
+                ) : (
+                  <Circle className="text-muted-foreground/60 size-4 shrink-0" />
+                )}
+                <div className="min-w-0 flex-1">
+                  <div
+                    className={`flex items-center gap-2 text-sm ${
+                      item.checkedIn ? "text-muted-foreground" : ""
+                    }`}
+                  >
+                    <span className="truncate">
+                      {item.guestName ?? "名前未登録"}
+                    </span>
+                    {totalCompanions > 0 && (
+                      <span className="text-muted-foreground border-border/60 shrink-0 rounded-full border px-1.5 text-[10px] tabular-nums">
+                        +{totalCompanions}
+                      </span>
+                    )}
+                  </div>
+                  {displayCompanions.length > 0 && searchQuery && (
+                    <div className="text-muted-foreground mt-0.5 text-xs">
+                      {displayCompanions.map((c) => c.name).join("、")}
+                    </div>
+                  )}
+                </div>
+                {item.checkedIn && item.checkedInAt && (
+                  <span className="text-muted-foreground text-xs tabular-nums">
+                    {formatTimestamp(item.checkedInAt)}
+                  </span>
+                )}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
+// ============================================================
+// Sub: ScanningView
+// ============================================================
+
+type ScanningViewProps = {
+  scanKey: number;
+  onScan: (decoded: string) => void;
+  onCancel: () => void;
+};
+
+function ScanningView({ scanKey, onScan, onCancel }: ScanningViewProps) {
+  return (
+    <div className="space-y-5 pt-4">
+      <div className="text-muted-foreground text-[10px] font-medium tracking-[0.28em] uppercase">
+        Scanning
+      </div>
+      <QrScanner key={scanKey} onScan={onScan} />
+      <p className="text-muted-foreground text-center text-xs tracking-wide">
+        QR コードをフレーム内に収めてください
+      </p>
+      <div className="flex justify-center">
+        <Button
+          variant="outline"
+          onClick={onCancel}
+          className="gap-2 rounded-full"
+        >
+          <X className="size-4" />
+          キャンセル
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================
+// Sub: FoundPanel (Dialog 中身)
+// ============================================================
+
+type FoundPanelProps = {
+  invitation: LookupInvitation;
   processing: string | null;
   onCheckIn: (
     invitationId: string,
@@ -716,158 +811,185 @@ type ResultPanelProps = {
     targetType: "guest" | "companion",
     targetId?: string,
   ) => void;
+  onBulk: (invitationId: string) => void;
+  onClose: () => void;
   onRescan: () => void;
-  /** dialog の中か inline か。dialog ではカードの枠を省略する */
-  variant?: "inline" | "dialog";
 };
 
-function ResultPanel({
-  viewState,
+function FoundPanel({
+  invitation: inv,
   processing,
   onCheckIn,
   onUndo,
+  onBulk,
+  onClose,
   onRescan,
-  variant = "inline",
-}: ResultPanelProps) {
-  if (viewState.mode === "loading") {
-    return (
-      <div className="flex flex-col items-center gap-2 py-8">
-        <Spinner className="size-8 animate-spin" />
-        <p className="text-muted-foreground text-sm">照会中...</p>
-      </div>
-    );
-  }
+}: FoundPanelProps) {
+  const totalPeople = 1 + inv.companions.length;
+  const remainingPending =
+    (inv.checkedIn ? 0 : 1) + inv.companions.filter((c) => !c.checkedIn).length;
+  const allDone = remainingPending === 0;
+  const lastCheckedInAt = useMemo(() => {
+    const times = [
+      inv.checkedIn ? inv.checkedInAt : null,
+      ...inv.companions.map((c) => (c.checkedIn ? c.checkedInAt : null)),
+    ].filter((t): t is number => t !== null);
+    return times.length > 0 ? Math.max(...times) : null;
+  }, [inv]);
 
-  if (viewState.mode === "error") {
-    const body = (
-      <div className="flex flex-col items-center gap-4 pt-6">
-        <Warning className="text-destructive size-10" />
-        <p className="text-destructive text-center text-sm">
-          {viewState.message}
+  return (
+    <div className="space-y-4">
+      {inv.guestEmail && (
+        <p className="text-muted-foreground -mt-2 text-xs tabular-nums">
+          {inv.guestEmail} · 合計 {totalPeople} 名
         </p>
-        <Button variant="outline" onClick={onRescan}>
-          再スキャン
-        </Button>
-      </div>
-    );
-    if (variant === "dialog") return body;
-    return (
-      <Card>
-        <CardContent>{body}</CardContent>
-      </Card>
-    );
-  }
+      )}
+      {!inv.guestEmail && (
+        <p className="text-muted-foreground -mt-2 text-xs tabular-nums">
+          合計 {totalPeople} 名
+        </p>
+      )}
 
-  const inv = viewState.invitation;
-  const body = (
-    <div className="space-y-3">
-      {/* ゲスト本人 */}
-      <div className="flex min-h-14 items-center justify-between rounded-md border p-3">
-        <div className="flex items-center gap-2">
-          <User className="text-muted-foreground size-4" />
-          <span className="text-sm font-medium">本人</span>
-          {inv.checkedIn && inv.checkedInAt && (
-            <span className="text-muted-foreground text-xs">
-              {formatTimestamp(inv.checkedInAt)}
-            </span>
-          )}
-        </div>
-        {inv.checkedIn ? (
-          <div className="flex items-center gap-2">
-            <CheckCircle className="size-5 text-emerald-800/70" weight="fill" />
-            <button
-              type="button"
-              className="text-muted-foreground text-xs underline"
-              disabled={processing === "guest"}
-              onClick={() => onUndo(inv.id, "guest")}
-            >
-              取り消し
-            </button>
-          </div>
-        ) : (
-          <Button
-            size="sm"
-            disabled={processing === "guest"}
-            onClick={() => onCheckIn(inv.id, "guest")}
-          >
-            チェックイン
-          </Button>
-        )}
+      <div className="space-y-2">
+        <PersonRow
+          label="本人"
+          name={inv.guestName ?? "名前未登録"}
+          checkedIn={inv.checkedIn}
+          checkedInAt={inv.checkedInAt}
+          processing={processing === "guest" || processing === "bulk"}
+          onCheckIn={() => onCheckIn(inv.id, "guest")}
+          onUndo={() => onUndo(inv.id, "guest")}
+        />
+        {inv.companions.map((c) => (
+          <PersonRow
+            key={c.id}
+            label="同伴"
+            name={c.name}
+            checkedIn={c.checkedIn}
+            checkedInAt={c.checkedInAt}
+            processing={processing === c.id || processing === "bulk"}
+            onCheckIn={() => onCheckIn(inv.id, "companion", c.id)}
+            onUndo={() => onUndo(inv.id, "companion", c.id)}
+          />
+        ))}
       </div>
 
-      {/* 同伴者 */}
-      {inv.companions.map((companion) => (
-        <div
-          key={companion.id}
-          className="flex min-h-14 items-center justify-between rounded-md border p-3"
+      {remainingPending >= 2 && (
+        <Button
+          variant="outline"
+          className="w-full rounded-full text-xs"
+          disabled={processing !== null}
+          onClick={() => onBulk(inv.id)}
         >
-          <div className="flex items-center gap-2">
-            <Users className="text-muted-foreground size-4" />
-            <span className="text-sm font-medium">{companion.name}</span>
-            {companion.checkedIn && companion.checkedInAt && (
-              <span className="text-muted-foreground text-xs">
-                {formatTimestamp(companion.checkedInAt)}
-              </span>
-            )}
-          </div>
-          {companion.checkedIn ? (
-            <div className="flex items-center gap-2">
-              <CheckCircle
-                className="size-5 text-emerald-800/70"
-                weight="fill"
-              />
-              <button
-                type="button"
-                className="text-muted-foreground text-xs underline"
-                disabled={processing === companion.id}
-                onClick={() => onUndo(inv.id, "companion", companion.id)}
-              >
-                取り消し
-              </button>
-            </div>
-          ) : (
-            <Button
-              size="sm"
-              disabled={processing === companion.id}
-              onClick={() => onCheckIn(inv.id, "companion", companion.id)}
-            >
-              チェックイン
-            </Button>
-          )}
-        </div>
-      ))}
+          残り {remainingPending} 名を一括チェックイン
+        </Button>
+      )}
 
-      {/* 次のゲストボタン */}
-      <div className="flex justify-center pt-2">
-        <Button variant="outline" onClick={onRescan} className="gap-2">
+      {allDone && lastCheckedInAt && (
+        <div className="flex items-center justify-center gap-2 rounded-md bg-emerald-700/10 px-3 py-2.5 text-[10px] font-medium tracking-[0.18em] text-emerald-800 uppercase">
+          <CheckCircle className="size-3.5" weight="fill" />
+          All checked in · {formatTimestamp(lastCheckedInAt)}
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 gap-2 pt-1">
+        <Button variant="outline" onClick={onClose}>
+          閉じる
+        </Button>
+        <Button onClick={onRescan} className="gap-2">
           <QrCode className="size-4" />
           次のゲスト
         </Button>
       </div>
     </div>
   );
+}
 
-  if (variant === "dialog") {
-    return (
-      <div>
-        {inv.guestEmail && (
-          <p className="text-muted-foreground text-sm mb-3">{inv.guestEmail}</p>
-        )}
-        {body}
-      </div>
-    );
-  }
+// ============================================================
+// Sub: PersonRow
+// ============================================================
+
+type PersonRowProps = {
+  label: "本人" | "同伴";
+  name: string;
+  checkedIn: boolean;
+  checkedInAt: number | null;
+  processing: boolean;
+  onCheckIn: () => void;
+  onUndo: () => void;
+};
+
+function PersonRow({
+  label,
+  name,
+  checkedIn,
+  checkedInAt,
+  processing,
+  onCheckIn,
+  onUndo,
+}: PersonRowProps) {
+  // 直前の checkedIn 状態を覚えておき、false → true の遷移時のみ flash アニメ
+  const prevCheckedIn = useRef(checkedIn);
+  const [flashKey, setFlashKey] = useState(0);
+  useEffect(() => {
+    if (!prevCheckedIn.current && checkedIn) {
+      setFlashKey((k) => k + 1);
+    }
+    prevCheckedIn.current = checkedIn;
+  }, [checkedIn]);
+
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="text-base">
-          {inv.guestName ?? "名前未登録"}
-        </CardTitle>
-        {inv.guestEmail && (
-          <p className="text-muted-foreground text-sm">{inv.guestEmail}</p>
-        )}
-      </CardHeader>
-      <CardContent>{body}</CardContent>
-    </Card>
+    <motion.div
+      key={flashKey}
+      initial={
+        flashKey > 0 ? { backgroundColor: "rgba(16,185,129,0.16)" } : false
+      }
+      animate={{ backgroundColor: "rgba(16,185,129,0)" }}
+      transition={{ duration: 0.6, ease: "easeOut" }}
+      className="bg-card flex items-center gap-3 rounded-lg border p-3"
+    >
+      {checkedIn ? (
+        <motion.div
+          key={`check-${flashKey}`}
+          initial={flashKey > 0 ? { scale: 0 } : { scale: 1 }}
+          animate={{ scale: 1 }}
+          transition={{
+            duration: 0.42,
+            ease: [0.34, 1.56, 0.64, 1],
+          }}
+        >
+          <CheckCircle className="size-5 text-emerald-700" weight="fill" />
+        </motion.div>
+      ) : (
+        <Circle className="text-muted-foreground/60 size-5 shrink-0" />
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="text-muted-foreground text-[9px] font-medium tracking-[0.22em] uppercase">
+          {label}
+        </div>
+        <div className="truncate text-sm font-medium">{name}</div>
+      </div>
+      {checkedIn ? (
+        <div className="flex items-center gap-3">
+          {checkedInAt && (
+            <span className="text-muted-foreground text-xs tabular-nums">
+              {formatTimestamp(checkedInAt)}
+            </span>
+          )}
+          <button
+            type="button"
+            className="text-muted-foreground text-xs underline underline-offset-2"
+            disabled={processing}
+            onClick={onUndo}
+          >
+            取り消し
+          </button>
+        </div>
+      ) : (
+        <Button size="sm" disabled={processing} onClick={onCheckIn}>
+          チェックイン
+        </Button>
+      )}
+    </motion.div>
   );
 }

--- a/src/app/_components/check-in-view.tsx
+++ b/src/app/_components/check-in-view.tsx
@@ -264,7 +264,8 @@ export function CheckInView({
       if (viewState.mode === "found") {
         const updated = { ...viewState.invitation };
         updated.checkedIn = true;
-        updated.checkedInAt = ts;
+        // 本人が既済だった場合は DB の既存時刻を保持（bulk の now で上書きしない）
+        updated.checkedInAt = result.guest.updated ? ts : updated.checkedInAt;
         updated.companions = updated.companions.map((c) => ({
           ...c,
           checkedIn: true,
@@ -356,13 +357,13 @@ export function CheckInView({
           guestNameMatched || matchedCompanions.length > 0,
       )
       .map(({ item, guestNameMatched, matchedCompanions }) => {
-        // 表示する子行: クエリありなら matchedCompanions、なしなら全員
+        // 表示する子行: クエリなし or guest 名マッチ → 同伴者全員、companion 名のみマッチ → マッチした子行のみ
         const displayCompanions =
-          q === "" ? item.companions : matchedCompanions;
+          q === "" || guestNameMatched ? item.companions : matchedCompanions;
         return { item, guestNameMatched, displayCompanions };
       })
       .filter(({ item, displayCompanions }) => {
-        // 未来場 / 来場済 切替
+        // 未来場 / 来場済 切替（招待全体（本人 + 表示中の同伴者）の状態で判定）
         if (isDoneFilter) {
           return item.checkedIn || displayCompanions.some((c) => c.checkedIn);
         }
@@ -423,7 +424,7 @@ export function CheckInView({
   return (
     <div className="mx-auto max-w-md px-4 pb-32">
       {/* Sticky top: イベント名 + ステータス */}
-      <div className="bg-background/80 supports-[backdrop-filter]:bg-background/60 sticky top-0 z-10 -mx-4 mb-2 border-b px-4 py-3 backdrop-blur-md">
+      <div className="bg-background/80 supports-[backdrop-filter]:bg-background/60 sticky top-14 z-10 -mx-4 mb-2 border-b px-4 py-3 backdrop-blur-md">
         <div className="flex items-center justify-between gap-3">
           <div className="min-w-0">
             <div className="text-muted-foreground text-[10px] font-medium tracking-[0.2em] uppercase">
@@ -710,6 +711,19 @@ function RosterSection({
         )}
         {filteredList.map(({ item, displayCompanions }) => {
           const totalCompanions = item.companions.length;
+          // 招待全体（本人 + 全同伴者）の状態で判定
+          const allCheckedIn =
+            item.checkedIn && item.companions.every((c) => c.checkedIn);
+          const someCheckedIn =
+            item.checkedIn || item.companions.some((c) => c.checkedIn);
+          const partial = someCheckedIn && !allCheckedIn;
+          // 全員済の場合に表示する最終 checkedInAt（本人 + 同伴者の最大値）
+          const finalCheckedInAt = allCheckedIn
+            ? Math.max(
+                item.checkedInAt ?? 0,
+                ...item.companions.map((c) => c.checkedInAt ?? 0),
+              )
+            : 0;
           return (
             <li key={item.id}>
               <button
@@ -717,10 +731,15 @@ function RosterSection({
                 onClick={() => onSelect(item)}
                 className="hover:bg-muted/40 flex w-full items-center gap-3 px-1 py-3 text-left transition-colors"
               >
-                {item.checkedIn ? (
+                {allCheckedIn ? (
                   <CheckCircle
                     className="size-4 shrink-0 text-emerald-700"
                     weight="fill"
+                  />
+                ) : partial ? (
+                  <CheckCircle
+                    className="size-4 shrink-0 text-emerald-700/60"
+                    weight="duotone"
                   />
                 ) : (
                   <Circle className="text-muted-foreground/60 size-4 shrink-0" />
@@ -728,7 +747,7 @@ function RosterSection({
                 <div className="min-w-0 flex-1">
                   <div
                     className={`flex items-center gap-2 text-sm ${
-                      item.checkedIn ? "text-muted-foreground" : ""
+                      allCheckedIn ? "text-muted-foreground" : ""
                     }`}
                   >
                     <span className="truncate">
@@ -746,9 +765,9 @@ function RosterSection({
                     </div>
                   )}
                 </div>
-                {item.checkedIn && item.checkedInAt && (
+                {allCheckedIn && finalCheckedInAt > 0 && (
                   <span className="text-muted-foreground text-xs tabular-nums">
-                    {formatTimestamp(item.checkedInAt)}
+                    {formatTimestamp(finalCheckedInAt)}
                   </span>
                 )}
               </button>

--- a/src/app/_components/qr-scanner.tsx
+++ b/src/app/_components/qr-scanner.tsx
@@ -97,10 +97,24 @@ export function QrScanner({ onScan }: QrScannerProps) {
           </Button>
         </div>
       )}
-      <div
-        id={elementId}
-        className="w-full max-w-sm overflow-hidden rounded-lg"
-      />
+      <div className="relative w-full max-w-sm overflow-hidden rounded-2xl bg-black/85">
+        <div id={elementId} className="w-full" />
+        {status === "scanning" && (
+          <div className="pointer-events-none absolute inset-[14%]">
+            <span className="absolute top-0 left-0 size-7 rounded-tl-md border-t-[2.5px] border-l-[2.5px] border-white/85 [filter:drop-shadow(0_2px_6px_rgba(0,0,0,0.6))]" />
+            <span className="absolute top-0 right-0 size-7 rounded-tr-md border-t-[2.5px] border-r-[2.5px] border-white/85 [filter:drop-shadow(0_2px_6px_rgba(0,0,0,0.6))]" />
+            <span className="absolute bottom-0 left-0 size-7 rounded-bl-md border-b-[2.5px] border-l-[2.5px] border-white/85 [filter:drop-shadow(0_2px_6px_rgba(0,0,0,0.6))]" />
+            <span className="absolute bottom-0 right-0 size-7 rounded-br-md border-b-[2.5px] border-r-[2.5px] border-white/85 [filter:drop-shadow(0_2px_6px_rgba(0,0,0,0.6))]" />
+            <span
+              className="absolute inset-x-[6%] top-1/2 h-[1.5px] animate-[scan_2.6s_ease-in-out_infinite] bg-gradient-to-r from-transparent via-emerald-400 to-transparent shadow-[0_0_12px_rgba(16,185,129,0.5)]"
+              style={{
+                animationName: "qr-scan",
+              }}
+            />
+            <style>{`@keyframes qr-scan{0%,100%{transform:translateY(-44px);opacity:.4}50%{transform:translateY(44px);opacity:1}}`}</style>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/tests/db/actions/checkin.test.ts
+++ b/tests/db/actions/checkin.test.ts
@@ -3,7 +3,6 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   lookupInvitationByToken,
   performCheckIn,
-  searchInvitationByName,
   undoCheckIn,
 } from "@/app/(main)/events/[eventId]/checkin/_actions";
 import { db } from "@/db";
@@ -38,92 +37,6 @@ async function setupMember(
   loginAs(user);
   return { user, event, memberId };
 }
-
-describe("searchInvitationByName", () => {
-  it("guestName の部分一致で accepted の招待を返す", async () => {
-    const { event, memberId } = await setupMember();
-    const matched = await addInvitation({
-      eventId: event.id,
-      memberId,
-      status: "accepted",
-      guestName: "山田太郎",
-    });
-    // status=accepted 以外は除外される
-    await addInvitation({
-      eventId: event.id,
-      memberId,
-      status: "pending",
-      guestName: "山田花子",
-    });
-    await addInvitation({
-      eventId: event.id,
-      memberId,
-      status: "declined",
-      guestName: "山田次郎",
-    });
-    // 名前不一致
-    await addInvitation({
-      eventId: event.id,
-      memberId,
-      status: "accepted",
-      guestName: "鈴木一郎",
-    });
-
-    const result = await searchInvitationByName(event.id, "山田");
-    if ("error" in result) throw new Error(result.error);
-    expect(result.invitations).toHaveLength(1);
-    expect(result.invitations[0]).toMatchObject({
-      id: matched.id,
-      guestNameMatched: true,
-      matchedCompanionIds: [],
-    });
-  });
-
-  it("companion 名の部分一致でもヒットし、matchedCompanionIds が返る", async () => {
-    const { event, memberId } = await setupMember();
-    const inv = await addInvitation({
-      eventId: event.id,
-      memberId,
-      status: "accepted",
-      guestName: "ゲスト",
-    });
-    const c1 = await addCompanion({
-      invitationId: inv.id,
-      name: "佐藤次郎",
-    });
-    await addCompanion({
-      invitationId: inv.id,
-      name: "別人",
-    });
-
-    const result = await searchInvitationByName(event.id, "佐藤");
-    if ("error" in result) throw new Error(result.error);
-    expect(result.invitations).toHaveLength(1);
-    expect(result.invitations[0].guestNameMatched).toBe(false);
-    expect(result.invitations[0].matchedCompanionIds).toEqual([c1.id]);
-  });
-
-  it("空文字クエリでは空配列を返す", async () => {
-    const { event } = await setupMember();
-    const result = await searchInvitationByName(event.id, "   ");
-    if ("error" in result) throw new Error(result.error);
-    expect(result.invitations).toEqual([]);
-  });
-
-  it("ongoing 以外のイベントではエラー", async () => {
-    const { event } = await setupMember({ status: "published" });
-    const result = await searchInvitationByName(event.id, "誰か");
-    expect(result).toEqual({ error: expect.stringContaining("開催中") });
-  });
-
-  it("非メンバーは検索不可", async () => {
-    const event = await createEvent({ status: "ongoing" });
-    const stranger = await createUser();
-    loginAs(stranger);
-    const result = await searchInvitationByName(event.id, "誰か");
-    expect(result).toEqual({ error: "権限がありません" });
-  });
-});
 
 describe("lookupInvitationByToken", () => {
   it("accepted 招待の token から招待情報を返す", async () => {

--- a/tests/db/actions/checkin.test.ts
+++ b/tests/db/actions/checkin.test.ts
@@ -2,6 +2,7 @@ import { eq } from "drizzle-orm";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   lookupInvitationByToken,
+  performBulkCheckIn,
   performCheckIn,
   undoCheckIn,
 } from "@/app/(main)/events/[eventId]/checkin/_actions";
@@ -468,6 +469,242 @@ describe("undoCheckIn", () => {
       status: "accepted",
     });
     const result = await undoCheckIn(ownEvent.id, otherInv.id, "guest");
+    expect(result).toEqual({
+      error: expect.stringContaining("見つかりません"),
+    });
+  });
+});
+
+describe("performBulkCheckIn", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("全員未チェックイン: 本人 + 全同伴者を更新し updated=true を返す", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2030-01-01T10:00:00Z"));
+    const { event, memberId } = await setupMember();
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+    });
+    const compA = await addCompanion({ invitationId: inv.id });
+    const compB = await addCompanion({ invitationId: inv.id });
+
+    const now = Date.now();
+    const result = await performBulkCheckIn(event.id, inv.id);
+    if ("error" in result) throw new Error(result.error);
+
+    expect(result.checkedInAt).toBe(now);
+    expect(result.guest).toEqual({ updated: true });
+    expect(result.companions).toEqual(
+      expect.arrayContaining([
+        { id: compA.id, updated: true },
+        { id: compB.id, updated: true },
+      ]),
+    );
+    expect(result.companions).toHaveLength(2);
+    expect(result.summary).toMatchObject({
+      totalAccepted: 1,
+      checkedInGuests: 1,
+      checkedInCompanions: 2,
+    });
+
+    const invAfter = await db.query.invitations.findFirst({
+      where: eq(invitations.id, inv.id),
+    });
+    expect(invAfter).toMatchObject({ checkedIn: true, checkedInAt: now });
+    const compARow = await db.query.companions.findFirst({
+      where: eq(companions.id, compA.id),
+    });
+    const compBRow = await db.query.companions.findFirst({
+      where: eq(companions.id, compB.id),
+    });
+    expect(compARow).toMatchObject({ checkedIn: true, checkedInAt: now });
+    expect(compBRow).toMatchObject({ checkedIn: true, checkedInAt: now });
+  });
+
+  it("本人のみ既済: guest.updated=false、同伴者だけ更新", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2030-01-01T10:00:00Z"));
+    const guestExisting = 1_700_000_000_000;
+    const { event, memberId } = await setupMember();
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+      checkedIn: true,
+      checkedInAt: guestExisting,
+    });
+    const comp = await addCompanion({ invitationId: inv.id });
+
+    const now = Date.now();
+    const result = await performBulkCheckIn(event.id, inv.id);
+    if ("error" in result) throw new Error(result.error);
+
+    expect(result.guest).toEqual({ updated: false });
+    expect(result.companions).toEqual([{ id: comp.id, updated: true }]);
+
+    const invAfter = await db.query.invitations.findFirst({
+      where: eq(invitations.id, inv.id),
+    });
+    // 既存の checkedInAt は上書きされない
+    expect(invAfter?.checkedInAt).toBe(guestExisting);
+    const compRow = await db.query.companions.findFirst({
+      where: eq(companions.id, comp.id),
+    });
+    expect(compRow).toMatchObject({ checkedIn: true, checkedInAt: now });
+  });
+
+  it("同伴者の一部が既済: 既済は updated=false で時刻保持、未済のみ更新", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2030-01-01T10:00:00Z"));
+    const compExisting = 1_700_000_000_000;
+    const { event, memberId } = await setupMember();
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+    });
+    const done = await addCompanion({
+      invitationId: inv.id,
+      checkedIn: true,
+      checkedInAt: compExisting,
+    });
+    const todo = await addCompanion({ invitationId: inv.id });
+
+    const now = Date.now();
+    const result = await performBulkCheckIn(event.id, inv.id);
+    if ("error" in result) throw new Error(result.error);
+
+    expect(result.guest).toEqual({ updated: true });
+    expect(result.companions).toEqual(
+      expect.arrayContaining([
+        { id: done.id, updated: false },
+        { id: todo.id, updated: true },
+      ]),
+    );
+
+    const doneRow = await db.query.companions.findFirst({
+      where: eq(companions.id, done.id),
+    });
+    const todoRow = await db.query.companions.findFirst({
+      where: eq(companions.id, todo.id),
+    });
+    // 既済は時刻据え置き、未済は now
+    expect(doneRow).toMatchObject({
+      checkedIn: true,
+      checkedInAt: compExisting,
+    });
+    expect(todoRow).toMatchObject({ checkedIn: true, checkedInAt: now });
+  });
+
+  it("全員既済: guest.updated=false かつ companions 全部 updated=false（冪等）", async () => {
+    const guestExisting = 1_700_000_000_000;
+    const compExisting = 1_700_000_000_111;
+    const { event, memberId } = await setupMember();
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+      checkedIn: true,
+      checkedInAt: guestExisting,
+    });
+    const comp = await addCompanion({
+      invitationId: inv.id,
+      checkedIn: true,
+      checkedInAt: compExisting,
+    });
+
+    const result = await performBulkCheckIn(event.id, inv.id);
+    if ("error" in result) throw new Error(result.error);
+
+    expect(result.guest).toEqual({ updated: false });
+    expect(result.companions).toEqual([{ id: comp.id, updated: false }]);
+
+    const invAfter = await db.query.invitations.findFirst({
+      where: eq(invitations.id, inv.id),
+    });
+    const compRow = await db.query.companions.findFirst({
+      where: eq(companions.id, comp.id),
+    });
+    expect(invAfter?.checkedInAt).toBe(guestExisting);
+    expect(compRow?.checkedInAt).toBe(compExisting);
+  });
+
+  it("同伴者なし: companions が空配列で本人のみ更新", async () => {
+    const { event, memberId } = await setupMember();
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+    });
+
+    const result = await performBulkCheckIn(event.id, inv.id);
+    if ("error" in result) throw new Error(result.error);
+
+    expect(result.guest).toEqual({ updated: true });
+    expect(result.companions).toEqual([]);
+  });
+
+  it("ongoing 以外のイベントではエラー", async () => {
+    const { event, memberId } = await setupMember({ status: "published" });
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+    });
+    const result = await performBulkCheckIn(event.id, inv.id);
+    expect(result).toEqual({ error: expect.stringContaining("開催中") });
+  });
+
+  it("accepted 以外の招待にはチェックインできない", async () => {
+    const { event, memberId } = await setupMember();
+    const pending = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "pending",
+    });
+    const result = await performBulkCheckIn(event.id, pending.id);
+    expect(result).toEqual({ error: expect.stringContaining("出席") });
+  });
+
+  it("invalidated 招待にはチェックインできない", async () => {
+    const { event, memberId } = await setupMember();
+    const inv = await addInvitation({
+      eventId: event.id,
+      memberId,
+      status: "accepted",
+      invalidatedAt: 1,
+    });
+    const result = await performBulkCheckIn(event.id, inv.id);
+    expect(result).toEqual({ error: expect.stringContaining("無効化") });
+  });
+
+  it("非メンバーは実行不可", async () => {
+    const event = await createEvent({ status: "ongoing" });
+    const stranger = await createUser();
+    loginAs(stranger);
+    const result = await performBulkCheckIn(event.id, "any");
+    expect(result).toEqual({ error: "権限がありません" });
+  });
+
+  it("別イベント配下の invitationId はエラー", async () => {
+    const { event: ownEvent } = await setupMember();
+    const otherEvent = await createEvent({ status: "ongoing" });
+    const otherUser = await createUser();
+    const otherMember = await addEventMember({
+      eventId: otherEvent.id,
+      userId: otherUser.id,
+      role: "organizer",
+    });
+    const otherInv = await addInvitation({
+      eventId: otherEvent.id,
+      memberId: otherMember,
+      status: "accepted",
+    });
+    const result = await performBulkCheckIn(ownEvent.id, otherInv.id);
     expect(result).toEqual({
       error: expect.stringContaining("見つかりません"),
     });


### PR DESCRIPTION
## Summary

- ピアノ発表会当日、受付スタッフがスマホ片手で数十〜百人を捌く現場を支える UX に再設計（コンセプト: **Concert Hall Lobby** — 数字は読ませる、アクションは反射で押させる、状態は一秒で読み取らせる）
- ヒーロー（円弧リング + 巨大数字）/ ROSTER（検索 + 未来場・来場済セグメント + 一覧）/ Sticky Bottom CTA / Dialog 改修の三層構造で構成
- `performBulkCheckIn` Server Action を追加、`searchInvitationByName` は廃止しローカルフィルタに統一

## 主な変更

- **画面構造**: Sticky Header → ヒーロー → ROSTER → Sticky Bottom CTA。`max-w-4xl` から `max-w-md` に絞ってスマホ片手操作の親指可動域を最優先
- **ヒーロー**: SVG 円弧プログレスリング + 巨大数字 (`font-light tabular-nums`) + サブ統計 (本人/同伴/残)。motion で 800ms カウントアップ
- **ROSTER**: 検索バー + ToggleGroup（未来場 N / 来場済 N）+ 一覧を統合。検索はローカルフィルタに簡素化
- **QR スキャン**: 画面下部 sticky CTA で常時タップ可能（safe-area-inset 対応）。スキャン中はビューを画面の主役に切替
- **スキャナ overlay**: 四隅 L 字角マーク + emerald 走査線（CSS keyframes 2.6s ease-in-out）
- **Dialog**: 本人/同伴を同じカード形状で並列表示。残り 2 名以上で「一括チェックイン」を表示、全員済時は完了リボン
- **完了アニメ**: チェックイン成功で CheckCircle が spring pop（motion）+ 行が emerald flash 600ms
- **配色ルール**: emerald は完了状態のみ、CTA・進行中はすべて primary（墨色）
- **触覚**: vibrate API で成功/エラーフィードバック

## Test plan

- [x] `pnpm lint` PASS
- [x] `pnpm type-check` PASS
- [x] `pnpm build` PASS
- [x] `pnpm vitest run tests/db/actions/checkin.test.ts` PASS (25/25)
- [ ] `/events/[eventId]/checkin` を ongoing イベントで開き、ヒーロー / ROSTER / sticky CTA / スキャン中 / Dialog の表示を目視
- [ ] チェックイン操作で CheckCircle pop + flash + ヒーローのカウントアップを確認
- [ ] 残り 2 名以上で「一括チェックイン」が出ること、押すと本人 + 全同伴者がまとめて済になることを確認
- [ ] イベント status が finished の状態で「チェックインは開催中のイベントでのみ利用できます」が出ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)