### PR TITLE
chore(deps): pnpm 10.33.4 → 11.1.2 移行

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
 node = "lts"
-pnpm = "10.33.4"
+"npm:pnpm" = "11.1.2"

--- a/package.json
+++ b/package.json
@@ -23,14 +23,9 @@
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio"
   },
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.1.2",
   "engines": {
     "node": "v24.15.0"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "lefthook"
-    ]
   },
   "dependencies": {
     "@emulators/adapter-next": "0.5.0",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,6 @@
 minimumReleaseAge: 4320
+allowBuilds:
+  lefthook: true
+  better-sqlite3: true
+  sharp: true
+  esbuild: true


### PR DESCRIPTION
## Summary

- pnpm を v11.1.2 に上げる。Renovate #125 が触れない breaking change の追従コミット
- `onlyBuiltDependencies` 廃止 → `pnpm-workspace.yaml` の `allowBuilds` に移行（pnpm 11 で `strictDepBuilds: true` がデフォルト化）
- mise の pnpm backend を aqua から npm に切り替え（aqua レジストリが pnpm 11 のアセット命名規則に追従していないため）

## Why

- pnpm 11 では `onlyBuiltDependencies` / `neverBuiltDependencies` などビルド許可系の設定がすべて廃止され、`allowBuilds` に統合された
- 同時に `strictDepBuilds: true` がデフォルト化し、未許可のビルドスクリプトを持つ依存があると `pnpm install` がエラー終了する
- Renovate PR #125 はバージョン文字列のみの差分で、上記設定移行を含まないため CI が全 job 失敗する状態だった

## 影響範囲

| ファイル | 変更 |
|---|---|
| `package.json` | `packageManager` 更新、`pnpm.onlyBuiltDependencies` 削除 |
| `mise.toml` | キー名 `pnpm` → `"npm:pnpm"`、値 `11.1.2` |
| `pnpm-workspace.yaml` | `allowBuilds` 追加（lefthook / better-sqlite3 / sharp / esbuild） |

`pnpm-lock.yaml` は差分なし（lockfile v9 が pnpm 10/11 で互換）。

## Test plan

- [x] `pnpm --version` → `11.1.2`
- [x] `pnpm install --frozen-lockfile` exit 0（`ERR_PNPM_IGNORED_BUILDS` が出ない）
- [x] `pnpm type-check` exit 0
- [x] `pnpm test:unit` exit 0（7 件）
- [x] `pnpm test:db` exit 0（151 件、better-sqlite3 native 動作確認）
- [x] `pnpm build` exit 0（next / sharp / esbuild / serwist まで完走）
- [ ] CI の lint / type-check / test×3 が緑になる
- [ ] Vercel preview deploy が成功する

## Follow-up

- マージ後、Renovate PR #125 を手動で close する
- `.workflow/` 配下のレビュー成果物がローカルで Biome lint に引っかかる既存問題は別 Issue 化候補（ローカルのみで CI には影響なし、本 PR とは無関係）

Refs #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)