### PR TITLE
feat(event): 会場に住所と座標を追加し地図プレビューを表示

### DIFF
--- a/drizzle/0001_swift_famine.sql
+++ b/drizzle/0001_swift_famine.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `events` ADD `address` text;--> statement-breakpoint
+ALTER TABLE `events` ADD `latitude` real;--> statement-breakpoint
+ALTER TABLE `events` ADD `longitude` real;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,1090 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ac70268c-9f59-4327-94ba-5eec90c3a74d",
+  "prevId": "9f15733f-7a3f-406e-9778-0baff223536d",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companions": {
+      "name": "companions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checked_in": {
+          "name": "checked_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "checked_in_at": {
+          "name": "checked_in_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "companions_invitation_id_idx": {
+          "name": "companions_invitation_id_idx",
+          "columns": ["invitation_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "companions_invitation_id_invitations_id_fk": {
+          "name": "companions_invitation_id_invitations_id_fk",
+          "tableFrom": "companions",
+          "tableTo": "invitations",
+          "columnsFrom": ["invitation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_members": {
+      "name": "event_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'performer'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "event_members_event_id_idx": {
+          "name": "event_members_event_id_idx",
+          "columns": ["event_id"],
+          "isUnique": false
+        },
+        "event_members_user_id_idx": {
+          "name": "event_members_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "event_members_event_user_unique": {
+          "name": "event_members_event_user_unique",
+          "columns": ["event_id", "user_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "event_members_event_id_events_id_fk": {
+          "name": "event_members_event_id_events_id_fk",
+          "tableFrom": "event_members",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_members_user_id_users_id_fk": {
+          "name": "event_members_user_id_users_id_fk",
+          "tableFrom": "event_members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "venue": {
+          "name": "venue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_datetime": {
+          "name": "start_datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "open_datetime": {
+          "name": "open_datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "total_seats": {
+          "name": "total_seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_program_id": {
+          "name": "current_program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitations": {
+      "name": "invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inviter_display_name": {
+          "name": "inviter_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_name": {
+          "name": "guest_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "guest_email": {
+          "name": "guest_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "checked_in": {
+          "name": "checked_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "checked_in_at": {
+          "name": "checked_in_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invalidated_at": {
+          "name": "invalidated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invitations_token_unique": {
+          "name": "invitations_token_unique",
+          "columns": ["token"],
+          "isUnique": true
+        },
+        "invitations_event_id_idx": {
+          "name": "invitations_event_id_idx",
+          "columns": ["event_id"],
+          "isUnique": false
+        },
+        "invitations_member_id_idx": {
+          "name": "invitations_member_id_idx",
+          "columns": ["member_id"],
+          "isUnique": false
+        },
+        "invitations_token_idx": {
+          "name": "invitations_token_idx",
+          "columns": ["token"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "invitations_event_id_events_id_fk": {
+          "name": "invitations_event_id_events_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_member_id_event_members_id_fk": {
+          "name": "invitations_member_id_event_members_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "event_members",
+          "columnsFrom": ["member_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "performer_invitations": {
+      "name": "performer_invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "performer_invitations_token_unique": {
+          "name": "performer_invitations_token_unique",
+          "columns": ["token"],
+          "isUnique": true
+        },
+        "performer_invitations_event_id_idx": {
+          "name": "performer_invitations_event_id_idx",
+          "columns": ["event_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "performer_invitations_event_id_events_id_fk": {
+          "name": "performer_invitations_event_id_events_id_fk",
+          "tableFrom": "performer_invitations",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "performer_invitations_accepted_by_user_id_users_id_fk": {
+          "name": "performer_invitations_accepted_by_user_id_users_id_fk",
+          "tableFrom": "performer_invitations",
+          "tableTo": "users",
+          "columnsFrom": ["accepted_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "program_performers": {
+      "name": "program_performers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "program_performers_program_id_idx": {
+          "name": "program_performers_program_id_idx",
+          "columns": ["program_id"],
+          "isUnique": false
+        },
+        "program_performers_member_id_idx": {
+          "name": "program_performers_member_id_idx",
+          "columns": ["member_id"],
+          "isUnique": false
+        },
+        "program_performers_unique": {
+          "name": "program_performers_unique",
+          "columns": ["program_id", "member_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "program_performers_program_id_programs_id_fk": {
+          "name": "program_performers_program_id_programs_id_fk",
+          "tableFrom": "program_performers",
+          "tableTo": "programs",
+          "columnsFrom": ["program_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_performers_member_id_event_members_id_fk": {
+          "name": "program_performers_member_id_event_members_id_fk",
+          "tableFrom": "program_performers",
+          "tableTo": "event_members",
+          "columnsFrom": ["member_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "program_pieces": {
+      "name": "program_pieces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "composer": {
+          "name": "composer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "program_pieces_program_id_idx": {
+          "name": "program_pieces_program_id_idx",
+          "columns": ["program_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "program_pieces_program_id_programs_id_fk": {
+          "name": "program_pieces_program_id_programs_id_fk",
+          "tableFrom": "program_pieces",
+          "tableTo": "programs",
+          "columnsFrom": ["program_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "programs": {
+      "name": "programs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_time": {
+          "name": "scheduled_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "estimated_duration": {
+          "name": "estimated_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "programs_event_id_idx": {
+          "name": "programs_event_id_idx",
+          "columns": ["event_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "programs_event_id_events_id_fk": {
+          "name": "programs_event_id_events_id_fk",
+          "tableFrom": "programs",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": ["token"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": ["email"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verifications": {
+      "name": "verifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1776226633330,
       "tag": "0000_sweet_the_hood",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1779497191296,
+      "tag": "0001_swift_famine",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(main)/events/_actions.ts
+++ b/src/app/(main)/events/_actions.ts
@@ -27,6 +27,9 @@ const createEventSchema = z.object({
     .regex(/^\d{2}:\d{2}$/)
     .optional(),
   venue: z.string().min(1).max(200),
+  address: z.string().max(300).optional(),
+  latitude: z.coerce.number().min(-90).max(90).optional(),
+  longitude: z.coerce.number().min(-180).max(180).optional(),
   totalSeats: z.number().int().min(0).max(9999),
 });
 
@@ -46,6 +49,9 @@ const updateEventSchema = z.object({
     .nullable()
     .optional(),
   venue: z.string().min(1).max(200).optional(),
+  address: z.string().max(300).nullable().optional(),
+  latitude: z.coerce.number().min(-90).max(90).nullable().optional(),
+  longitude: z.coerce.number().min(-180).max(180).nullable().optional(),
   totalSeats: z.number().int().min(0).max(9999).optional(),
 });
 
@@ -67,6 +73,9 @@ type CreateEventFields = {
   startTime: string;
   openTime: string;
   venue: string;
+  address: string;
+  latitude: string;
+  longitude: string;
   totalSeats: string;
 };
 
@@ -88,6 +97,9 @@ function extractFields(formData: FormData): CreateEventFields {
     startTime: (formData.get("startTime") as string) ?? "",
     openTime: (formData.get("openTime") as string) ?? "",
     venue: (formData.get("venue") as string) ?? "",
+    address: (formData.get("address") as string) ?? "",
+    latitude: (formData.get("latitude") as string) ?? "",
+    longitude: (formData.get("longitude") as string) ?? "",
     totalSeats: (formData.get("totalSeats") as string) ?? "",
   };
 }
@@ -105,6 +117,9 @@ export async function createEvent(
     startTime: formData.get("startTime"),
     openTime: formData.get("openTime") || undefined,
     venue: formData.get("venue"),
+    address: formData.get("address") || undefined,
+    latitude: formData.get("latitude") || undefined,
+    longitude: formData.get("longitude") || undefined,
     totalSeats: Number(formData.get("totalSeats")),
   });
 
@@ -150,6 +165,9 @@ export async function createEvent(
     .values({
       name: rest.name,
       venue: rest.venue,
+      address: rest.address ?? null,
+      latitude: rest.latitude ?? null,
+      longitude: rest.longitude ?? null,
       startDatetime,
       openDatetime,
       totalSeats: rest.totalSeats,
@@ -208,6 +226,15 @@ export async function updateEvent(
       ? formData.get("openTime") || null
       : undefined,
     venue: formData.get("venue") || undefined,
+    address: formData.has("address")
+      ? formData.get("address") || null
+      : undefined,
+    latitude: formData.has("latitude")
+      ? formData.get("latitude") || null
+      : undefined,
+    longitude: formData.has("longitude")
+      ? formData.get("longitude") || null
+      : undefined,
     totalSeats: formData.has("totalSeats")
       ? Number(formData.get("totalSeats"))
       : undefined,
@@ -224,6 +251,9 @@ export async function updateEvent(
 
   if (rest.name !== undefined) updateData.name = rest.name;
   if (rest.venue !== undefined) updateData.venue = rest.venue;
+  if (rest.address !== undefined) updateData.address = rest.address;
+  if (rest.latitude !== undefined) updateData.latitude = rest.latitude;
+  if (rest.longitude !== undefined) updateData.longitude = rest.longitude;
   if (rest.totalSeats !== undefined) {
     if (rest.totalSeats > 0) {
       const consumed = await getConsumedSeats(eventId);

--- a/src/app/_components/create-event-dialog.tsx
+++ b/src/app/_components/create-event-dialog.tsx
@@ -98,12 +98,20 @@ export function CreateEventDialog() {
             defaultVenue={stateFields?.venue}
             defaultAddress={stateFields?.address || null}
             defaultLatitude={
-              stateFields?.latitude ? Number(stateFields.latitude) : null
+              stateFields?.latitude !== undefined && stateFields.latitude !== ""
+                ? Number(stateFields.latitude)
+                : null
             }
             defaultLongitude={
-              stateFields?.longitude ? Number(stateFields.longitude) : null
+              stateFields?.longitude !== undefined &&
+              stateFields.longitude !== ""
+                ? Number(stateFields.longitude)
+                : null
             }
             venueError={fieldErrors?.venue}
+            addressError={fieldErrors?.address}
+            latitudeError={fieldErrors?.latitude}
+            longitudeError={fieldErrors?.longitude}
           />
 
           <div className="grid gap-4 sm:grid-cols-2">

--- a/src/app/_components/create-event-dialog.tsx
+++ b/src/app/_components/create-event-dialog.tsx
@@ -21,6 +21,7 @@ import {
   ResponsiveModalTitle,
   ResponsiveModalTrigger,
 } from "@/components/ui/responsive-modal";
+import { VenueField } from "./venue-field";
 
 export function CreateEventDialog() {
   const [open, setOpen] = useState(false);
@@ -30,7 +31,6 @@ export function CreateEventDialog() {
   const dateId = useId();
   const startTimeId = useId();
   const openTimeId = useId();
-  const venueId = useId();
   const totalSeatsId = useId();
   const unlimitedId = useId();
 
@@ -94,21 +94,17 @@ export function CreateEventDialog() {
             )}
           </div>
 
-          <div className="flex flex-col gap-2">
-            <Label htmlFor={venueId}>会場</Label>
-            <Input
-              type="text"
-              id={venueId}
-              name="venue"
-              required
-              maxLength={200}
-              defaultValue={stateFields?.venue}
-              aria-invalid={fieldErrors?.venue ? true : undefined}
-            />
-            {fieldErrors?.venue && (
-              <p className="text-destructive text-xs">{fieldErrors.venue}</p>
-            )}
-          </div>
+          <VenueField
+            defaultVenue={stateFields?.venue}
+            defaultAddress={stateFields?.address || null}
+            defaultLatitude={
+              stateFields?.latitude ? Number(stateFields.latitude) : null
+            }
+            defaultLongitude={
+              stateFields?.longitude ? Number(stateFields.longitude) : null
+            }
+            venueError={fieldErrors?.venue}
+          />
 
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="flex flex-col gap-2">

--- a/src/app/_components/event-detail.tsx
+++ b/src/app/_components/event-detail.tsx
@@ -247,6 +247,7 @@ export function EventDetail({
               />
             </div>
             <VenueField
+              mode="update"
               defaultVenue={event.venue}
               defaultAddress={event.address}
               defaultLatitude={event.latitude}

--- a/src/app/_components/event-detail.tsx
+++ b/src/app/_components/event-detail.tsx
@@ -47,12 +47,17 @@ import {
 } from "@/lib/event-status";
 import { formatDatetime } from "@/lib/format";
 import type { EventStats } from "@/lib/queries/events";
+import { VenueField } from "./venue-field";
+import { VenueMap } from "./venue-map";
 
 type EventDetailProps = {
   event: {
     id: string;
     name: string;
     venue: string;
+    address: string | null;
+    latitude: number | null;
+    longitude: number | null;
     startDatetime: string;
     openDatetime: string | null;
     status: EventStatus;
@@ -151,30 +156,43 @@ export function EventDetail({
         </div>
 
         {!isEditing && (
-          <dl className="grid gap-6 border-border/60 border-y py-6 md:grid-cols-3">
-            <FactItem
-              icon={<CalendarBlank className="h-4 w-4" aria-hidden />}
-              label="開演"
-              value={formatDatetime(event.startDatetime)}
-              sub={
-                event.openDatetime
-                  ? `開場 ${formatDatetime(event.openDatetime)}`
-                  : null
-              }
-            />
-            <FactItem
-              icon={<MapPin className="h-4 w-4" aria-hidden />}
-              label="会場"
-              value={event.venue}
-            />
-            <FactItem
-              icon={<IdentificationCard className="h-4 w-4" aria-hidden />}
-              label="座席"
-              value={
-                event.totalSeats === 0 ? "無制限" : `${event.totalSeats} 席`
-              }
-            />
-          </dl>
+          <>
+            <dl className="grid gap-6 border-border/60 border-y py-6 md:grid-cols-3">
+              <FactItem
+                icon={<CalendarBlank className="h-4 w-4" aria-hidden />}
+                label="開演"
+                value={formatDatetime(event.startDatetime)}
+                sub={
+                  event.openDatetime
+                    ? `開場 ${formatDatetime(event.openDatetime)}`
+                    : null
+                }
+              />
+              <FactItem
+                icon={<MapPin className="h-4 w-4" aria-hidden />}
+                label="会場"
+                value={event.venue}
+                sub={event.address ?? null}
+              />
+              <FactItem
+                icon={<IdentificationCard className="h-4 w-4" aria-hidden />}
+                label="座席"
+                value={
+                  event.totalSeats === 0 ? "無制限" : `${event.totalSeats} 席`
+                }
+              />
+            </dl>
+            {event.latitude !== null && event.longitude !== null && (
+              <div className="pt-6">
+                <VenueMap
+                  venue={event.venue}
+                  address={event.address}
+                  latitude={event.latitude}
+                  longitude={event.longitude}
+                />
+              </div>
+            )}
+          </>
         )}
       </header>
 
@@ -228,17 +246,12 @@ export function EventDetail({
                 defaultValue={event.openDatetime?.split("T")[1] ?? ""}
               />
             </div>
-            <div className="flex flex-col gap-2">
-              <Label htmlFor="venue">会場</Label>
-              <Input
-                type="text"
-                id="venue"
-                name="venue"
-                required
-                maxLength={200}
-                defaultValue={event.venue}
-              />
-            </div>
+            <VenueField
+              defaultVenue={event.venue}
+              defaultAddress={event.address}
+              defaultLatitude={event.latitude}
+              defaultLongitude={event.longitude}
+            />
             <div className="flex flex-col gap-2">
               <Label htmlFor="totalSeats">座席数（0 = 無制限）</Label>
               <Input

--- a/src/app/_components/venue-field.tsx
+++ b/src/app/_components/venue-field.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { MagnifyingGlass, MapPin, X } from "@phosphor-icons/react";
+import { Info, MagnifyingGlass, MapPin, X } from "@phosphor-icons/react";
 import { useEffect, useId, useRef, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -20,6 +20,15 @@ type Props = {
   defaultLatitude?: number | null;
   defaultLongitude?: number | null;
   venueError?: string;
+  addressError?: string;
+  latitudeError?: string;
+  longitudeError?: string;
+  /**
+   * "update" のときは初期値から変更があったフィールドだけ hidden input に
+   * name を付ける。変更されていないフィールドは form に乗らないので、
+   * Server Action 側で他者が並行更新した値を上書きしない。
+   */
+  mode?: "create" | "update";
 };
 
 export function VenueField({
@@ -28,11 +37,21 @@ export function VenueField({
   defaultLatitude = null,
   defaultLongitude = null,
   venueError,
+  addressError,
+  latitudeError,
+  longitudeError,
+  mode = "create",
 }: Props) {
   const [venue, setVenue] = useState(defaultVenue);
   const [address, setAddress] = useState<string | null>(defaultAddress);
   const [latitude, setLatitude] = useState<number | null>(defaultLatitude);
   const [longitude, setLongitude] = useState<number | null>(defaultLongitude);
+
+  // サジェストから選んだ会場名を保持。venue と一致しているときだけ
+  // 「地図と整合した状態」とみなす。
+  const [selectedName, setSelectedName] = useState<string | null>(
+    defaultLatitude !== null && defaultLongitude !== null ? defaultVenue : null,
+  );
 
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [isSearching, setIsSearching] = useState(false);
@@ -44,12 +63,31 @@ export function VenueField({
   const blurTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const hasCoordinates = latitude !== null && longitude !== null;
+  const isMapMatchingVenue = hasCoordinates && venue === selectedName;
   const showSuggestions =
-    isFocused && suggestions.length > 0 && !hasCoordinates;
+    isFocused && suggestions.length > 0 && !isMapMatchingVenue;
+
+  // 初期値スナップショット — update モードでの dirty 判定に使う
+  const initial = useRef({
+    venue: defaultVenue,
+    address: defaultAddress,
+    latitude: defaultLatitude,
+    longitude: defaultLongitude,
+  });
+  const shouldSend = (changed: boolean) => mode !== "update" || changed;
+
+  const clearBlurTimer = () => {
+    if (blurTimerRef.current) {
+      clearTimeout(blurTimerRef.current);
+      blurTimerRef.current = null;
+    }
+  };
 
   useEffect(() => {
     const trimmed = venue.trim();
-    if (trimmed.length < 2 || hasCoordinates) {
+    // 地図と venue が一致しているときだけ検索をスキップ。
+    // ユーザーが会場名を編集して selectedName と乖離したら再検索が走る。
+    if (trimmed.length < 2 || isMapMatchingVenue) {
       setSuggestions([]);
       setIsSearching(false);
       return;
@@ -72,7 +110,11 @@ export function VenueField({
           return;
         }
         const data = (await res.json()) as Suggestion[];
-        if (!cancelled) setSuggestions(data);
+        // 上流が NaN を返したアイテムは除外（lat/lon が壊れたケース）
+        const safe = data.filter(
+          (s) => Number.isFinite(s.latitude) && Number.isFinite(s.longitude),
+        );
+        if (!cancelled) setSuggestions(safe);
       } catch {
         if (!cancelled) {
           setHasError(true);
@@ -87,11 +129,15 @@ export function VenueField({
       cancelled = true;
       clearTimeout(timer);
     };
-  }, [venue, hasCoordinates]);
+  }, [venue, isMapMatchingVenue]);
 
   useEffect(() => {
+    // unmount 時のタイマー解放
     return () => {
-      if (blurTimerRef.current) clearTimeout(blurTimerRef.current);
+      if (blurTimerRef.current) {
+        clearTimeout(blurTimerRef.current);
+        blurTimerRef.current = null;
+      }
     };
   }, []);
 
@@ -100,14 +146,17 @@ export function VenueField({
     setAddress(s.address);
     setLatitude(s.latitude);
     setLongitude(s.longitude);
+    setSelectedName(s.name);
     setSuggestions([]);
     setIsFocused(false);
+    clearBlurTimer();
   };
 
   const handleClearLocation = () => {
     setAddress(null);
     setLatitude(null);
     setLongitude(null);
+    setSelectedName(null);
   };
 
   return (
@@ -120,10 +169,16 @@ export function VenueField({
             id={venueId}
             value={venue}
             onChange={(e) => setVenue(e.target.value)}
-            onFocus={() => setIsFocused(true)}
+            onFocus={() => {
+              clearBlurTimer();
+              setIsFocused(true);
+            }}
             onBlur={() => {
-              // クリック判定のため少し遅延
-              blurTimerRef.current = setTimeout(() => setIsFocused(false), 150);
+              clearBlurTimer();
+              blurTimerRef.current = setTimeout(() => {
+                setIsFocused(false);
+                blurTimerRef.current = null;
+              }, 150);
             }}
             required
             maxLength={200}
@@ -190,6 +245,13 @@ export function VenueField({
 
       {hasCoordinates && latitude !== null && longitude !== null && (
         <div className="flex flex-col gap-2">
+          {!isMapMatchingVenue && (
+            <p className="flex items-start gap-2 rounded-sm border border-amber-500/40 bg-amber-50/60 px-3 py-2 text-[11px] text-amber-900 tracking-wider dark:bg-amber-950/30 dark:text-amber-200">
+              <Info className="mt-0.5 size-3.5 shrink-0" aria-hidden />
+              会場名を変更しました。地図と一致しない場合は、サジェストから選び直すか「クリア」してください。
+            </p>
+          )}
+
           <div className="flex flex-col gap-2">
             <Label htmlFor={addressId}>住所</Label>
             <Input
@@ -199,7 +261,11 @@ export function VenueField({
               onChange={(e) => setAddress(e.target.value || null)}
               maxLength={300}
               placeholder="任意。サジェストから取得した住所が入ります"
+              aria-invalid={addressError ? true : undefined}
             />
+            {addressError && (
+              <p className="text-destructive text-xs">{addressError}</p>
+            )}
           </div>
 
           <VenueMap
@@ -221,17 +287,45 @@ export function VenueField({
         </div>
       )}
 
-      {/* hidden inputs for form submission */}
-      <input type="hidden" name="venue" value={venue} />
-      <input type="hidden" name="address" value={address ?? ""} />
+      {(latitudeError || longitudeError) && (
+        <p className="text-destructive text-xs">
+          {latitudeError ?? longitudeError}
+        </p>
+      )}
+
+      {/*
+        hidden inputs for form submission.
+        update モードでは初期値から変更があったフィールドのみ name を付与する。
+        name 無しの hidden input は formData に乗らないので、Server Action 側で
+        formData.has(...) が false → updateData にセットされず、他者の並行更新を
+        上書きしない。
+      */}
       <input
         type="hidden"
-        name="latitude"
+        {...(shouldSend(venue !== initial.current.venue)
+          ? { name: "venue" }
+          : {})}
+        value={venue}
+      />
+      <input
+        type="hidden"
+        {...(shouldSend(address !== initial.current.address)
+          ? { name: "address" }
+          : {})}
+        value={address ?? ""}
+      />
+      <input
+        type="hidden"
+        {...(shouldSend(latitude !== initial.current.latitude)
+          ? { name: "latitude" }
+          : {})}
         value={latitude !== null ? String(latitude) : ""}
       />
       <input
         type="hidden"
-        name="longitude"
+        {...(shouldSend(longitude !== initial.current.longitude)
+          ? { name: "longitude" }
+          : {})}
         value={longitude !== null ? String(longitude) : ""}
       />
     </div>

--- a/src/app/_components/venue-field.tsx
+++ b/src/app/_components/venue-field.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { MagnifyingGlass, MapPin, X } from "@phosphor-icons/react";
+import { useEffect, useId, useRef, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { client } from "@/lib/rpc";
+import { VenueMap } from "./venue-map";
+
+type Suggestion = {
+  name: string;
+  address: string;
+  latitude: number;
+  longitude: number;
+};
+
+type Props = {
+  defaultVenue?: string;
+  defaultAddress?: string | null;
+  defaultLatitude?: number | null;
+  defaultLongitude?: number | null;
+  venueError?: string;
+};
+
+export function VenueField({
+  defaultVenue = "",
+  defaultAddress = null,
+  defaultLatitude = null,
+  defaultLongitude = null,
+  venueError,
+}: Props) {
+  const [venue, setVenue] = useState(defaultVenue);
+  const [address, setAddress] = useState<string | null>(defaultAddress);
+  const [latitude, setLatitude] = useState<number | null>(defaultLatitude);
+  const [longitude, setLongitude] = useState<number | null>(defaultLongitude);
+
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
+  const [hasError, setHasError] = useState(false);
+
+  const venueId = useId();
+  const addressId = useId();
+  const blurTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const hasCoordinates = latitude !== null && longitude !== null;
+  const showSuggestions =
+    isFocused && suggestions.length > 0 && !hasCoordinates;
+
+  useEffect(() => {
+    const trimmed = venue.trim();
+    if (trimmed.length < 2 || hasCoordinates) {
+      setSuggestions([]);
+      setIsSearching(false);
+      return;
+    }
+
+    let cancelled = false;
+    setIsSearching(true);
+    setHasError(false);
+
+    const timer = setTimeout(async () => {
+      try {
+        const res = await client.api.places.search.$get({
+          query: { q: trimmed, limit: "5" },
+        });
+        if (!res.ok) {
+          if (!cancelled) {
+            setHasError(true);
+            setSuggestions([]);
+          }
+          return;
+        }
+        const data = (await res.json()) as Suggestion[];
+        if (!cancelled) setSuggestions(data);
+      } catch {
+        if (!cancelled) {
+          setHasError(true);
+          setSuggestions([]);
+        }
+      } finally {
+        if (!cancelled) setIsSearching(false);
+      }
+    }, 300);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [venue, hasCoordinates]);
+
+  useEffect(() => {
+    return () => {
+      if (blurTimerRef.current) clearTimeout(blurTimerRef.current);
+    };
+  }, []);
+
+  const handleSelect = (s: Suggestion) => {
+    setVenue(s.name);
+    setAddress(s.address);
+    setLatitude(s.latitude);
+    setLongitude(s.longitude);
+    setSuggestions([]);
+    setIsFocused(false);
+  };
+
+  const handleClearLocation = () => {
+    setAddress(null);
+    setLatitude(null);
+    setLongitude(null);
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-2">
+        <Label htmlFor={venueId}>会場</Label>
+        <div className="relative">
+          <Input
+            type="text"
+            id={venueId}
+            value={venue}
+            onChange={(e) => setVenue(e.target.value)}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => {
+              // クリック判定のため少し遅延
+              blurTimerRef.current = setTimeout(() => setIsFocused(false), 150);
+            }}
+            required
+            maxLength={200}
+            placeholder="例: 東京文化会館"
+            aria-invalid={venueError ? true : undefined}
+            aria-autocomplete="list"
+            aria-expanded={showSuggestions}
+            className="pr-9"
+          />
+          <span className="-translate-y-1/2 pointer-events-none absolute top-1/2 right-3 text-muted-foreground/60">
+            {isSearching ? (
+              <span className="block size-3 animate-spin rounded-full border border-current border-t-transparent" />
+            ) : (
+              <MagnifyingGlass className="size-4" aria-hidden />
+            )}
+          </span>
+
+          {showSuggestions && (
+            <ul className="absolute z-20 mt-1 flex w-full flex-col divide-y divide-border/40 overflow-hidden rounded-sm border border-border/60 bg-popover shadow-sm">
+              {suggestions.map((s, i) => (
+                <li
+                  // biome-ignore lint/suspicious/noArrayIndexKey: ordering by API rank is stable per query
+                  key={`${s.latitude}-${s.longitude}-${i}`}
+                >
+                  <button
+                    type="button"
+                    onMouseDown={(e) => {
+                      // input の blur より先に発火させる
+                      e.preventDefault();
+                      handleSelect(s);
+                    }}
+                    className="flex w-full items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/60 focus:bg-muted/60 focus:outline-none"
+                  >
+                    <MapPin
+                      className="mt-1 size-3.5 shrink-0 text-muted-foreground"
+                      aria-hidden
+                    />
+                    <div className="flex min-w-0 flex-col gap-0.5">
+                      <span className="truncate font-light font-serif text-foreground text-sm">
+                        {s.name}
+                      </span>
+                      <span className="truncate text-[11px] text-muted-foreground tracking-wider">
+                        {s.address}
+                      </span>
+                    </div>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        {venueError && <p className="text-destructive text-xs">{venueError}</p>}
+        {hasError && !venueError && (
+          <p className="text-muted-foreground text-xs">
+            場所の検索に失敗しました。会場名は手入力で保存できます。
+          </p>
+        )}
+        {!hasCoordinates && !venueError && (
+          <p className="text-[11px] text-muted-foreground/80 tracking-wider">
+            会場名を入力するとサジェストが出ます。地図に載っていない場所はそのまま入力してください。
+          </p>
+        )}
+      </div>
+
+      {hasCoordinates && latitude !== null && longitude !== null && (
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor={addressId}>住所</Label>
+            <Input
+              type="text"
+              id={addressId}
+              value={address ?? ""}
+              onChange={(e) => setAddress(e.target.value || null)}
+              maxLength={300}
+              placeholder="任意。サジェストから取得した住所が入ります"
+            />
+          </div>
+
+          <VenueMap
+            venue={venue || "会場"}
+            address={address}
+            latitude={latitude}
+            longitude={longitude}
+            height={200}
+          />
+
+          <button
+            type="button"
+            onClick={handleClearLocation}
+            className="inline-flex items-center gap-1 self-start text-muted-foreground text-xs tracking-wider transition-colors hover:text-foreground"
+          >
+            <X className="size-3" aria-hidden />
+            地図と住所をクリア
+          </button>
+        </div>
+      )}
+
+      {/* hidden inputs for form submission */}
+      <input type="hidden" name="venue" value={venue} />
+      <input type="hidden" name="address" value={address ?? ""} />
+      <input
+        type="hidden"
+        name="latitude"
+        value={latitude !== null ? String(latitude) : ""}
+      />
+      <input
+        type="hidden"
+        name="longitude"
+        value={longitude !== null ? String(longitude) : ""}
+      />
+    </div>
+  );
+}

--- a/src/app/_components/venue-map.tsx
+++ b/src/app/_components/venue-map.tsx
@@ -1,0 +1,78 @@
+import { ArrowUpRight, MapPin } from "@phosphor-icons/react/dist/ssr";
+
+type Props = {
+  venue: string;
+  address?: string | null;
+  latitude: number;
+  longitude: number;
+  height?: number;
+  className?: string;
+};
+
+export function VenueMap({
+  venue,
+  address,
+  latitude,
+  longitude,
+  height = 240,
+  className,
+}: Props) {
+  const delta = 0.005;
+  const minLng = longitude - delta;
+  const minLat = latitude - delta;
+  const maxLng = longitude + delta;
+  const maxLat = latitude + delta;
+  const bbox = `${minLng},${minLat},${maxLng},${maxLat}`;
+  const embedSrc = `https://www.openstreetmap.org/export/embed.html?bbox=${bbox}&layer=mapnik&marker=${latitude},${longitude}`;
+  const openUrl = `https://www.openstreetmap.org/?mlat=${latitude}&mlon=${longitude}#map=17/${latitude}/${longitude}`;
+
+  return (
+    <figure
+      className={`overflow-hidden rounded-sm border border-border/60 bg-card ${className ?? ""}`}
+    >
+      <figcaption className="flex items-start gap-3 px-5 py-4">
+        <MapPin
+          className="mt-1 size-4 shrink-0 text-muted-foreground"
+          aria-hidden
+        />
+        <div className="flex flex-col gap-1">
+          <span className="font-light font-serif text-base text-foreground leading-tight">
+            {venue}
+          </span>
+          {address && (
+            <span className="text-muted-foreground text-xs leading-relaxed tracking-wider">
+              {address}
+            </span>
+          )}
+        </div>
+      </figcaption>
+
+      <div className="border-border/60 border-t bg-muted/30">
+        <iframe
+          title={`${venue} の地図`}
+          src={embedSrc}
+          width="100%"
+          height={height}
+          loading="lazy"
+          referrerPolicy="no-referrer"
+          className="block w-full"
+        />
+      </div>
+
+      <div className="flex items-center justify-between border-border/60 border-t px-5 py-3">
+        <span className="text-[10px] text-muted-foreground tracking-[0.18em] uppercase">
+          © OpenStreetMap contributors
+        </span>
+        <a
+          href={openUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-muted-foreground text-xs tracking-wider transition-colors hover:text-foreground"
+        >
+          地図で開く
+          <ArrowUpRight className="size-3" aria-hidden />
+        </a>
+      </div>
+    </figure>
+  );
+}

--- a/src/app/_components/venue-map.tsx
+++ b/src/app/_components/venue-map.tsx
@@ -18,10 +18,11 @@ export function VenueMap({
   className,
 }: Props) {
   const delta = 0.005;
-  const minLng = longitude - delta;
-  const minLat = latitude - delta;
-  const maxLng = longitude + delta;
-  const maxLat = latitude + delta;
+  // 経度は ±180、緯度は ±90 でクランプ。日付変更線/極地でも範囲外にしない。
+  const minLng = Math.max(-180, longitude - delta);
+  const minLat = Math.max(-90, latitude - delta);
+  const maxLng = Math.min(180, longitude + delta);
+  const maxLat = Math.min(90, latitude + delta);
   const bbox = `${minLng},${minLat},${maxLng},${maxLat}`;
   const embedSrc = `https://www.openstreetmap.org/export/embed.html?bbox=${bbox}&layer=mapnik&marker=${latitude},${longitude}`;
   const openUrl = `https://www.openstreetmap.org/?mlat=${latitude}&mlon=${longitude}#map=17/${latitude}/${longitude}`;
@@ -55,6 +56,8 @@ export function VenueMap({
           height={height}
           loading="lazy"
           referrerPolicy="no-referrer"
+          // OpenStreetMap embed が動く範囲で第三者コンテンツの権限を絞る
+          sandbox="allow-scripts allow-same-origin allow-popups"
           className="block w-full"
         />
       </div>

--- a/src/app/i/[token]/page.tsx
+++ b/src/app/i/[token]/page.tsx
@@ -7,6 +7,7 @@ import {
 import { InvitationProgramView } from "@/app/_components/invitation-program-view";
 import { InvitationResponseForm } from "@/app/_components/invitation-response-form";
 import { QrCode } from "@/app/_components/qr-code";
+import { VenueMap } from "@/app/_components/venue-map";
 import type { EventStatus } from "@/db/schema";
 import { formatDate, formatDatetime, formatTime } from "@/lib/format";
 import { getInvitationByToken } from "@/lib/queries/invitations";
@@ -57,6 +58,9 @@ function EventInfoHeader({
   event: {
     name: string;
     venue: string;
+    address: string | null;
+    latitude: number | null;
+    longitude: number | null;
     startDatetime: string;
     openDatetime: string | null;
   };
@@ -80,12 +84,19 @@ function EventInfoHeader({
         <dt className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
           会場
         </dt>
-        <dd className="text-sm">
-          <span className="tabular-nums">
-            {formatDate(event.startDatetime)}
+        <dd className="flex flex-col gap-1 text-sm">
+          <span>
+            <span className="tabular-nums">
+              {formatDate(event.startDatetime)}
+            </span>
+            {" ／ "}
+            {event.venue}
           </span>
-          {" ／ "}
-          {event.venue}
+          {event.address && (
+            <span className="text-muted-foreground text-xs tracking-wider">
+              {event.address}
+            </span>
+          )}
         </dd>
         {event.openDatetime && (
           <>
@@ -104,6 +115,16 @@ function EventInfoHeader({
           {formatTime(event.startDatetime)}
         </dd>
       </dl>
+      {event.latitude !== null && event.longitude !== null && (
+        <div className="animate-in fade-in slide-in-from-bottom-2 duration-700 delay-300 motion-reduce:animate-none motion-reduce:delay-0">
+          <VenueMap
+            venue={event.venue}
+            address={event.address}
+            latitude={event.latitude}
+            longitude={event.longitude}
+          />
+        </div>
+      )}
     </header>
   );
 }

--- a/src/app/join/[token]/page.tsx
+++ b/src/app/join/[token]/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { JoinEventForm } from "@/app/_components/join-event-form";
+import { VenueMap } from "@/app/_components/venue-map";
 import { formatDatetime, formatTime } from "@/lib/format";
 import { getEventMembership } from "@/lib/queries/events";
 import { getPerformerInvitationByToken } from "@/lib/queries/members";
@@ -49,6 +50,9 @@ function PerformerInvitationHeader({
   event: {
     name: string;
     venue: string;
+    address: string | null;
+    latitude: number | null;
+    longitude: number | null;
     startDatetime: string;
     openDatetime: string | null;
   };
@@ -87,8 +91,25 @@ function PerformerInvitationHeader({
         <dt className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
           会場
         </dt>
-        <dd className="text-sm">{event.venue}</dd>
+        <dd className="flex flex-col gap-1 text-sm">
+          <span>{event.venue}</span>
+          {event.address && (
+            <span className="text-muted-foreground text-xs tracking-wider">
+              {event.address}
+            </span>
+          )}
+        </dd>
       </dl>
+      {event.latitude !== null && event.longitude !== null && (
+        <div className="animate-in fade-in slide-in-from-bottom-1 duration-500 delay-200 fill-mode-both motion-reduce:animate-none motion-reduce:delay-0">
+          <VenueMap
+            venue={event.venue}
+            address={event.address}
+            latitude={event.latitude}
+            longitude={event.longitude}
+          />
+        </div>
+      )}
     </header>
   );
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -2,6 +2,7 @@ import { relations } from "drizzle-orm";
 import {
   index,
   integer,
+  real,
   sqliteTable,
   text,
   unique,
@@ -142,6 +143,9 @@ export const events = sqliteTable("events", {
     .$defaultFn(() => crypto.randomUUID()),
   name: text("name").notNull(),
   venue: text("venue").notNull(),
+  address: text("address"),
+  latitude: real("latitude"),
+  longitude: real("longitude"),
   startDatetime: text("start_datetime").notNull(),
   openDatetime: text("open_datetime"),
   status: text("status", { enum: EVENT_STATUSES }).notNull().default("draft"),

--- a/src/lib/queries/events.ts
+++ b/src/lib/queries/events.ts
@@ -16,6 +16,9 @@ export type EventWithRole = {
   id: string;
   name: string;
   venue: string;
+  address: string | null;
+  latitude: number | null;
+  longitude: number | null;
   startDatetime: string;
   openDatetime: string | null;
   status: EventStatus;
@@ -42,6 +45,9 @@ export const getEventsByUserId = cache(
         id: events.id,
         name: events.name,
         venue: events.venue,
+        address: events.address,
+        latitude: events.latitude,
+        longitude: events.longitude,
         startDatetime: events.startDatetime,
         openDatetime: events.openDatetime,
         status: events.status,
@@ -64,6 +70,9 @@ export const getEventsByUserId = cache(
         id: events.id,
         name: events.name,
         venue: events.venue,
+        address: events.address,
+        latitude: events.latitude,
+        longitude: events.longitude,
         startDatetime: events.startDatetime,
         openDatetime: events.openDatetime,
         status: events.status,

--- a/src/lib/queries/invitations.ts
+++ b/src/lib/queries/invitations.ts
@@ -58,6 +58,9 @@ export type InvitationForResponse = {
     id: string;
     name: string;
     venue: string;
+    address: string | null;
+    latitude: number | null;
+    longitude: number | null;
     startDatetime: string;
     openDatetime: string | null;
     status: EventStatus;
@@ -134,6 +137,9 @@ export async function getInvitationByToken(
           id: true,
           name: true,
           venue: true,
+          address: true,
+          latitude: true,
+          longitude: true,
           startDatetime: true,
           openDatetime: true,
           status: true,

--- a/src/lib/queries/members.ts
+++ b/src/lib/queries/members.ts
@@ -51,6 +51,9 @@ export type PerformerInvitationForJoin = {
     id: string;
     name: string;
     venue: string;
+    address: string | null;
+    latitude: number | null;
+    longitude: number | null;
     startDatetime: string;
     openDatetime: string | null;
     status: EventStatus;
@@ -133,6 +136,9 @@ export async function getPerformerInvitationByToken(
           id: true,
           name: true,
           venue: true,
+          address: true,
+          latitude: true,
+          longitude: true,
           startDatetime: true,
           openDatetime: true,
           status: true,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { auth } from "@/lib/auth";
 import { healthRoute } from "./routes/health";
+import { placesRoute } from "./routes/places";
 
 const app = new Hono().basePath("/api");
 
@@ -19,7 +20,7 @@ app.on(["POST", "GET"], "/auth/*", (c) => {
   return auth.handler(c.req.raw);
 });
 
-const routes = app.route("/health", healthRoute);
+const routes = app.route("/health", healthRoute).route("/places", placesRoute);
 
 export type AppType = typeof routes;
 export default app;

--- a/src/server/routes/places.ts
+++ b/src/server/routes/places.ts
@@ -1,0 +1,97 @@
+import { Hono } from "hono";
+import { z } from "zod";
+
+const NOMINATIM_ENDPOINT = "https://nominatim.openstreetmap.org/search";
+
+const querySchema = z.object({
+  q: z.string().min(1).max(200),
+  limit: z.coerce.number().int().min(1).max(10).optional(),
+});
+
+type NominatimItem = {
+  display_name: string;
+  lat: string;
+  lon: string;
+  name?: string;
+  address?: Record<string, string>;
+};
+
+export type PlaceSuggestion = {
+  name: string;
+  address: string;
+  latitude: number;
+  longitude: number;
+};
+
+const formatAddress = (item: NominatimItem): string => {
+  const addr = item.address ?? {};
+  const parts = [
+    addr.postcode ? `〒${addr.postcode}` : null,
+    addr.state ?? addr.province ?? null,
+    addr.city ?? addr.town ?? addr.village ?? addr.municipality ?? null,
+    addr.suburb ?? addr.neighbourhood ?? null,
+    addr.road ?? null,
+    addr.house_number ?? null,
+  ].filter((v): v is string => Boolean(v));
+  if (parts.length > 0) return parts.join(" ");
+  // address が無いか分解できない場合は display_name の末尾を落として返す
+  return item.display_name.replace(/, \d+,?\s*[^,]*$/, "");
+};
+
+const extractName = (item: NominatimItem): string => {
+  if (item.name?.trim()) return item.name.trim();
+  const first = item.display_name.split(",")[0]?.trim();
+  return first ?? item.display_name;
+};
+
+const app = new Hono().get("/search", async (c) => {
+  const parsed = querySchema.safeParse({
+    q: c.req.query("q") ?? "",
+    limit: c.req.query("limit"),
+  });
+  if (!parsed.success) {
+    return c.json({ error: "invalid query" }, 400);
+  }
+  const { q, limit = 5 } = parsed.data;
+
+  const baseUrl =
+    process.env.APP_PUBLIC_URL ??
+    process.env.BETTER_AUTH_URL ??
+    "http://localhost:3000";
+  const userAgent = `Lull/0.1 (${baseUrl})`;
+
+  const url = new URL(NOMINATIM_ENDPOINT);
+  url.searchParams.set("format", "jsonv2");
+  url.searchParams.set("q", q);
+  url.searchParams.set("limit", String(limit));
+  url.searchParams.set("addressdetails", "1");
+  url.searchParams.set("accept-language", "ja");
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: {
+        "User-Agent": userAgent,
+        Referer: baseUrl,
+      },
+    });
+  } catch {
+    return c.json({ error: "upstream unreachable" }, 502);
+  }
+
+  if (!res.ok) {
+    return c.json({ error: "upstream error", status: res.status }, 502);
+  }
+
+  const items = (await res.json()) as NominatimItem[];
+  const suggestions: PlaceSuggestion[] = items.map((item) => ({
+    name: extractName(item),
+    address: formatAddress(item),
+    latitude: Number(item.lat),
+    longitude: Number(item.lon),
+  }));
+
+  return c.json(suggestions);
+});
+
+export { app as placesRoute };

--- a/src/server/routes/places.ts
+++ b/src/server/routes/places.ts
@@ -83,13 +83,29 @@ const app = new Hono().get("/search", async (c) => {
     return c.json({ error: "upstream error", status: res.status }, 502);
   }
 
-  const items = (await res.json()) as NominatimItem[];
-  const suggestions: PlaceSuggestion[] = items.map((item) => ({
-    name: extractName(item),
-    address: formatAddress(item),
-    latitude: Number(item.lat),
-    longitude: Number(item.lon),
-  }));
+  const raw = (await res.json()) as unknown;
+  if (!Array.isArray(raw)) {
+    // Nominatim はレート制限超過などで配列以外を返すことがある
+    return c.json({ error: "upstream invalid response" }, 502);
+  }
+
+  const suggestions: PlaceSuggestion[] = (raw as NominatimItem[])
+    .map((item) => ({
+      name: extractName(item),
+      address: formatAddress(item),
+      latitude: Number(item.lat),
+      longitude: Number(item.lon),
+    }))
+    // 緯度経度が数値として復元できないアイテムは除外
+    .filter(
+      (s) =>
+        Number.isFinite(s.latitude) &&
+        Number.isFinite(s.longitude) &&
+        s.latitude >= -90 &&
+        s.latitude <= 90 &&
+        s.longitude >= -180 &&
+        s.longitude <= 180,
+    );
 
   return c.json(suggestions);
 });


### PR DESCRIPTION
## Summary
- events.venue を会場名のみ → 名前 + 住所 + 座標に拡張（address/latitude/longitude を nullable で追加）
- 入力 dialog で OSM Nominatim サジェスト → 選択 → 下に地図カードプレビュー、というフローを `VenueField` / `VenueMap` で実装
- 詳細ページ・ゲスト招待ページ (`/i/[token]`)・出演者招待ページ (`/join/[token]`) に地図カードを併置（座標がある場合のみ）
- 外部依存は API キー不要のもののみ：OSM Nominatim（Hono プロキシ経由で UA を `Lull/0.1 (...)` に固定）+ OpenStreetMap embed iframe。JS ライブラリ追加なし

## 設計メモ
- 地図ピンに会場名のポップアップは出さない（Leaflet 不要の構成）。会場名・住所はカード見出しにテキスト併置
- 既存データは座標が null のため、`event.latitude && event.longitude` で出し分け（後方互換）
- Nominatim Usage Policy 対応として、ブラウザから直接ではなく Hono ルートでプロキシし固定 UA / Referer を付与

## Test plan
- [x] `pnpm type-check` / `pnpm lint` / `pnpm vitest run`（158/158）
- [x] `curl /api/places/search` で 200 / 400 の挙動確認
- [x] preview モード + ui-verify (headed) で：
  - 作成 dialog: venue 入力 → サジェスト → 選択 → 地図カード展開 → 保存
  - 編集 form: 既存座標から VenueField/地図カードが復元
  - 詳細ページ: FactItem に住所サブ、下に地図カード
  - ゲスト招待ページ `/i/[token]`: ヘッダーに会場・住所・地図カード
- [ ] 出演者招待ページ `/join/[token]` のレイアウト目視確認（ゲスト側と対称な実装）

🤖 Generated with [Claude Code](https://claude.com/claude-code)