### PR TITLE
feat(invitation): RSVP 回答後に Resend でゲストへ確認メールを送信

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,12 @@ BETTER_AUTH_URL=http://localhost:3000
 # あわせて NEXT_PUBLIC_VERCEL_ENV=preview を preview scope に入れると @emulators/google が有効化される
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
+
+# 公開 URL（招待状リンクの組み立てや Nominatim の User-Agent に使う）
+APP_PUBLIC_URL=http://localhost:3000
+
+# Resend（招待 RSVP 通知メール）
+# 未設定なら実送信せず、メール内容をサーバーログに console.info で出す
+RESEND_API_KEY=
+# 送信元アドレス。未設定なら "Lull <invitation@lull.live>" が使われる
+# MAIL_FROM=Lull <invitation@lull.live>

--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,8 @@ GOOGLE_CLIENT_SECRET=
 APP_PUBLIC_URL=http://localhost:3000
 
 # Resend（招待 RSVP 通知メール）
-# 未設定なら実送信せず、メール内容をサーバーログに console.info で出す
+# dev / test では未設定でも動く（実送信せず宛先と件名のみ console.info に出す）
+# NODE_ENV=production で未設定の場合は MailerConfigError を throw する
 RESEND_API_KEY=
 # 送信元アドレス。未設定なら "Lull <invitation@lull.live>" が使われる
 # MAIL_FROM=Lull <invitation@lull.live>

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "radix-ui": "1.4.3",
     "react": "19.2.6",
     "react-dom": "19.2.6",
+    "resend": "^6.12.3",
     "server-only": "0.0.1",
     "serwist": "9.5.7",
     "sonner": "2.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       react-dom:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
+      resend:
+        specifier: ^6.12.3
+        version: 6.12.3
       server-only:
         specifier: 0.0.1
         version: 0.0.1
@@ -2460,6 +2463,9 @@ packages:
       typescript:
         optional: true
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -3302,6 +3308,9 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
 
@@ -3927,6 +3936,9 @@ packages:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
     engines: {node: '>=14.19.0'}
 
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
+
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -4061,6 +4073,15 @@ packages:
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
+  resend@6.12.3:
+    resolution: {integrity: sha512-FkEi6YPnVL96/LvH8+QP7NaeaBy5brYXwlRqUCqZZeNL0/iyKij18IPmyPXYauT/2ODn1JG04qKz+qlJfzqzTw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
+
   reserved-identifiers@1.2.0:
     resolution: {integrity: sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==}
     engines: {node: '>=18'}
@@ -4165,6 +4186,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
@@ -4253,6 +4277,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svix@1.92.2:
+    resolution: {integrity: sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==}
 
   tailwind-merge@3.6.0:
     resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
@@ -6469,6 +6496,8 @@ snapshots:
     transitivePeerDependencies:
       - browserslist
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@storybook/addon-a11y@10.4.0(storybook@10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
@@ -7262,6 +7291,8 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-string-truncated-width@3.0.3: {}
 
   fast-string-width@3.0.2:
@@ -7798,6 +7829,8 @@ snapshots:
 
   pngjs@7.0.0: {}
 
+  postal-mime@2.7.4: {}
+
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.11
@@ -7992,6 +8025,11 @@ snapshots:
 
   require-main-filename@2.0.0: {}
 
+  resend@6.12.3:
+    dependencies:
+      postal-mime: 2.7.4
+      svix: 1.92.2
+
   reserved-identifiers@1.2.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -8118,6 +8156,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   std-env@4.0.0: {}
 
   storybook@10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
@@ -8215,6 +8258,10 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svix@1.92.2:
+    dependencies:
+      standardwebhooks: 1.0.0
 
   tailwind-merge@3.6.0: {}
 

--- a/src/app/i/[token]/_actions.ts
+++ b/src/app/i/[token]/_actions.ts
@@ -2,6 +2,7 @@
 
 import { eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
+import { after } from "next/server";
 import * as z from "zod";
 import { db } from "@/db";
 import { companions, invitations } from "@/db/schema";
@@ -104,6 +105,20 @@ export async function respondToInvitation(
     return { error: "入力内容を確認してください", fieldErrors };
   }
 
+  // 編集時の guestEmail 改ざん防止
+  // 初回回答後は宛先メールアドレスを変更不可とし、招待トークンを使った
+  // 任意宛先への通知メール送信（spam relay）を防ぐ
+  if (
+    invitation.status !== "pending" &&
+    invitation.guestEmail !== null &&
+    invitation.guestEmail !== parsed.data.guestEmail
+  ) {
+    return {
+      error: "入力内容を確認してください",
+      fieldErrors: { guestEmail: "メールアドレスは変更できません" },
+    };
+  }
+
   const { attendance, companions: companionNames, ...guestInfo } = parsed.data;
   const prevStatus = invitation.status;
 
@@ -167,8 +182,14 @@ export async function respondToInvitation(
     companionNames: attendance === "accepted" ? companionNames : [],
     invitationUrl: `${getBaseUrl()}/i/${token}`,
   });
-  void sendMail({ to: guestInfo.guestEmail, ...mail }).catch((err) => {
-    console.error("[respondToInvitation] failed to send mail", err);
+  // レスポンス返却後に走らせる（serverless 環境で fire-and-forget が
+  // 切られる挙動を避ける）
+  after(async () => {
+    try {
+      await sendMail({ to: guestInfo.guestEmail, ...mail });
+    } catch (err) {
+      console.error("[respondToInvitation] failed to send mail", err);
+    }
   });
 
   revalidatePath(`/i/${token}`);

--- a/src/app/i/[token]/_actions.ts
+++ b/src/app/i/[token]/_actions.ts
@@ -5,7 +5,17 @@ import { revalidatePath } from "next/cache";
 import * as z from "zod";
 import { db } from "@/db";
 import { companions, invitations } from "@/db/schema";
+import { buildInvitationResponseMail } from "@/lib/emails/invitation-response";
+import { sendMail } from "@/lib/mailer";
 import { getConsumedSeats } from "@/lib/queries/invitations";
+
+function getBaseUrl(): string {
+  return (
+    process.env.APP_PUBLIC_URL ??
+    process.env.BETTER_AUTH_URL ??
+    "http://localhost:3000"
+  );
+}
 
 // NOTE: 成功時は undefined を返す（既存パターンに統一）
 export type ResponseActionState =
@@ -95,6 +105,7 @@ export async function respondToInvitation(
   }
 
   const { attendance, companions: companionNames, ...guestInfo } = parsed.data;
+  const prevStatus = invitation.status;
 
   // DB 更新（トランザクションで座席競合を防止）
   const txError = await db.transaction(async (tx) => {
@@ -146,6 +157,19 @@ export async function respondToInvitation(
   if (txError) {
     return { error: txError };
   }
+
+  const mail = buildInvitationResponseMail({
+    eventName: event.name,
+    guestName: guestInfo.guestName,
+    guestEmail: guestInfo.guestEmail,
+    attendance,
+    prevStatus,
+    companionNames: attendance === "accepted" ? companionNames : [],
+    invitationUrl: `${getBaseUrl()}/i/${token}`,
+  });
+  void sendMail({ to: guestInfo.guestEmail, ...mail }).catch((err) => {
+    console.error("[respondToInvitation] failed to send mail", err);
+  });
 
   revalidatePath(`/i/${token}`);
   revalidatePath(`/events/${event.id}/invitations`);

--- a/src/app/i/[token]/_actions.ts
+++ b/src/app/i/[token]/_actions.ts
@@ -7,15 +7,19 @@ import * as z from "zod";
 import { db } from "@/db";
 import { companions, invitations } from "@/db/schema";
 import { buildInvitationResponseMail } from "@/lib/emails/invitation-response";
-import { sendMail } from "@/lib/mailer";
+import { MailerConfigError, sendMail } from "@/lib/mailer";
 import { getConsumedSeats } from "@/lib/queries/invitations";
 
 function getBaseUrl(): string {
-  return (
-    process.env.APP_PUBLIC_URL ??
-    process.env.BETTER_AUTH_URL ??
-    "http://localhost:3000"
-  );
+  // 明示設定（trim 後の非空）が最優先
+  const explicit =
+    process.env.APP_PUBLIC_URL?.trim() || process.env.BETTER_AUTH_URL?.trim();
+  if (explicit) return explicit;
+  // Vercel の preview deploy 等では VERCEL_BRANCH_URL / VERCEL_URL を使う
+  // （src/lib/auth.ts の組み立て方と揃える）
+  const vercelHost = process.env.VERCEL_BRANCH_URL || process.env.VERCEL_URL;
+  if (vercelHost) return `https://${vercelHost}`;
+  return "http://localhost:3000";
 }
 
 // NOTE: 成功時は undefined を返す（既存パターンに統一）
@@ -107,10 +111,11 @@ export async function respondToInvitation(
 
   // 編集時の guestEmail 改ざん防止
   // 初回回答後は宛先メールアドレスを変更不可とし、招待トークンを使った
-  // 任意宛先への通知メール送信（spam relay）を防ぐ
+  // 任意宛先への通知メール送信（spam relay）を防ぐ。
+  // 既存値が null のケース（admin 代理操作などで status だけ進められた場合）
+  // でも変更不可とする
   if (
     invitation.status !== "pending" &&
-    invitation.guestEmail !== null &&
     invitation.guestEmail !== parsed.data.guestEmail
   ) {
     return {
@@ -189,6 +194,10 @@ export async function respondToInvitation(
       await sendMail({ to: guestInfo.guestEmail, ...mail });
     } catch (err) {
       console.error("[respondToInvitation] failed to send mail", err);
+      // 設定漏れ系は監視で拾えるよう Next.js runtime に伝播させる
+      if (err instanceof MailerConfigError) {
+        throw err;
+      }
     }
   });
 

--- a/src/lib/emails/invitation-response.ts
+++ b/src/lib/emails/invitation-response.ts
@@ -1,0 +1,70 @@
+import type { InvitationStatus } from "@/db/schema";
+
+export type InvitationResponseMailInput = {
+  eventName: string;
+  guestName: string;
+  guestEmail: string;
+  attendance: Exclude<InvitationStatus, "pending">;
+  prevStatus: InvitationStatus;
+  companionNames: string[];
+  invitationUrl: string;
+};
+
+export type InvitationResponseMail = {
+  subject: string;
+  text: string;
+};
+
+export function buildInvitationResponseMail(
+  input: InvitationResponseMailInput,
+): InvitationResponseMail {
+  const {
+    eventName,
+    guestName,
+    guestEmail,
+    attendance,
+    prevStatus,
+    companionNames,
+    invitationUrl,
+  } = input;
+
+  const subject =
+    attendance === "accepted"
+      ? `[Lull] 「${eventName}」への出席を承りました`
+      : `[Lull] 「${eventName}」の辞退を承りました`;
+
+  const lead =
+    prevStatus === "pending"
+      ? `「${eventName}」へのご回答を承りました。`
+      : `「${eventName}」への回答内容を更新しました。`;
+
+  const responseLines = [
+    `- 出欠: ${attendance === "accepted" ? "出席" : "辞退"}`,
+    `- お名前: ${guestName}`,
+    `- メール: ${guestEmail}`,
+  ];
+
+  if (attendance === "accepted") {
+    const companionsLabel =
+      companionNames.length > 0 ? companionNames.join("、") : "なし";
+    responseLines.push(`- 同伴者: ${companionsLabel}`);
+  }
+
+  const text = [
+    `${guestName} 様`,
+    "",
+    lead,
+    "",
+    "■ 回答内容",
+    ...responseLines,
+    "",
+    "■ 招待状",
+    invitationUrl,
+    "",
+    "回答内容の変更や、当日のご案内・受付の QR コードは上記リンクからご確認いただけます。",
+    "",
+    "— Lull",
+  ].join("\n");
+
+  return { subject, text };
+}

--- a/src/lib/emails/invitation-response.ts
+++ b/src/lib/emails/invitation-response.ts
@@ -28,10 +28,15 @@ export function buildInvitationResponseMail(
     invitationUrl,
   } = input;
 
+  // RFC 5322 上 subject ヘッダに CR/LF を入れられないため、event 名に
+  // 紛れ込んだ改行や制御文字をスペースに置換してヘッダーインジェクションと
+  // Resend API 拒否を防ぐ
+  const safeEventName = eventName.replace(/[\r\n\t]+/g, " ").trim();
+
   const subject =
     attendance === "accepted"
-      ? `[Lull] 「${eventName}」への出席を承りました`
-      : `[Lull] 「${eventName}」の辞退を承りました`;
+      ? `[Lull] 「${safeEventName}」への出席を承りました`
+      : `[Lull] 「${safeEventName}」の辞退を承りました`;
 
   const lead =
     prevStatus === "pending"

--- a/src/lib/emails/invitation-response.ts
+++ b/src/lib/emails/invitation-response.ts
@@ -28,9 +28,8 @@ export function buildInvitationResponseMail(
     invitationUrl,
   } = input;
 
-  // RFC 5322 上 subject ヘッダに CR/LF を入れられないため、event 名に
-  // 紛れ込んだ改行や制御文字をスペースに置換してヘッダーインジェクションと
-  // Resend API 拒否を防ぐ
+  // subject ヘッダのヘッダーインジェクション対策と、本文中の表示崩れ防止を
+  // 兼ねて event 名から CR/LF/Tab を除去する
   const safeEventName = eventName.replace(/[\r\n\t]+/g, " ").trim();
 
   const subject =
@@ -40,8 +39,8 @@ export function buildInvitationResponseMail(
 
   const lead =
     prevStatus === "pending"
-      ? `「${eventName}」へのご回答を承りました。`
-      : `「${eventName}」への回答内容を更新しました。`;
+      ? `「${safeEventName}」へのご回答を承りました。`
+      : `「${safeEventName}」への回答内容を更新しました。`;
 
   const responseLines = [
     `- 出欠: ${attendance === "accepted" ? "出席" : "辞退"}`,

--- a/src/lib/mailer.ts
+++ b/src/lib/mailer.ts
@@ -1,0 +1,50 @@
+import "server-only";
+
+import { Resend } from "resend";
+
+const DEFAULT_FROM = "Lull <invitation@lull.live>";
+
+let cachedClient: Resend | null = null;
+
+function getClient(apiKey: string): Resend {
+  if (!cachedClient) {
+    cachedClient = new Resend(apiKey);
+  }
+  return cachedClient;
+}
+
+export type SendMailInput = {
+  to: string;
+  subject: string;
+  text: string;
+};
+
+export async function sendMail({
+  to,
+  subject,
+  text,
+}: SendMailInput): Promise<void> {
+  const apiKey = process.env.RESEND_API_KEY;
+  const from = process.env.MAIL_FROM ?? DEFAULT_FROM;
+
+  if (!apiKey) {
+    console.info(
+      `[mailer] would send (RESEND_API_KEY not set)\nfrom: ${from}\nto: ${to}\nsubject: ${subject}\n---\n${text}`,
+    );
+    return;
+  }
+
+  const client = getClient(apiKey);
+  const result = await client.emails.send({
+    from,
+    to,
+    subject,
+    text,
+  });
+
+  if (result.error) {
+    throw new Error(
+      `[mailer] resend send failed: ${result.error.name}: ${result.error.message}`,
+    );
+  }
+}

--- a/src/lib/mailer.ts
+++ b/src/lib/mailer.ts
@@ -28,8 +28,14 @@ export async function sendMail({
   const from = process.env.MAIL_FROM ?? DEFAULT_FROM;
 
   if (!apiKey) {
+    // 本番では設定漏れに即時気付くよう fail-fast し、PII を含む本文を
+    // ログに残さない。dev / test では fallback として宛先と件名のみ出す
+    // （本文は出さない）
+    if (process.env.NODE_ENV === "production") {
+      throw new Error("[mailer] RESEND_API_KEY is required in production");
+    }
     console.info(
-      `[mailer] would send (RESEND_API_KEY not set)\nfrom: ${from}\nto: ${to}\nsubject: ${subject}\n---\n${text}`,
+      `[mailer] would send (RESEND_API_KEY not set) to=${to} subject=${subject}`,
     );
     return;
   }

--- a/src/lib/mailer.ts
+++ b/src/lib/mailer.ts
@@ -4,13 +4,13 @@ import { Resend } from "resend";
 
 const DEFAULT_FROM = "Lull <invitation@lull.live>";
 
-let cachedClient: Resend | null = null;
-
-function getClient(apiKey: string): Resend {
-  if (!cachedClient) {
-    cachedClient = new Resend(apiKey);
+// 設定漏れを呼び出し側で型分岐するための専用エラー（transient な送信失敗と
+// 区別したい）
+export class MailerConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MailerConfigError";
   }
-  return cachedClient;
 }
 
 export type SendMailInput = {
@@ -24,15 +24,17 @@ export async function sendMail({
   subject,
   text,
 }: SendMailInput): Promise<void> {
-  const apiKey = process.env.RESEND_API_KEY;
-  const from = process.env.MAIL_FROM ?? DEFAULT_FROM;
+  const apiKey = process.env.RESEND_API_KEY?.trim();
+  // 空文字 / 空白のみを「未設定」として扱うため `||` を使う
+  const from = process.env.MAIL_FROM?.trim() || DEFAULT_FROM;
 
   if (!apiKey) {
-    // 本番では設定漏れに即時気付くよう fail-fast し、PII を含む本文を
-    // ログに残さない。dev / test では fallback として宛先と件名のみ出す
-    // （本文は出さない）
+    // 本番では設定漏れに fail-fast、PII を含む本文をログに残さない。
+    // dev / test では宛先と件名のみ出す（本文は出さない）
     if (process.env.NODE_ENV === "production") {
-      throw new Error("[mailer] RESEND_API_KEY is required in production");
+      throw new MailerConfigError(
+        "[mailer] RESEND_API_KEY is required in production",
+      );
     }
     console.info(
       `[mailer] would send (RESEND_API_KEY not set) to=${to} subject=${subject}`,
@@ -40,7 +42,9 @@ export async function sendMail({
     return;
   }
 
-  const client = getClient(apiKey);
+  // Resend のインスタンス化は安価。シングルトンにすると key ローテーション
+  // 時に古いインスタンスが残るため都度生成する
+  const client = new Resend(apiKey);
   const result = await client.emails.send({
     from,
     to,

--- a/tests/db/actions/respond-invitation.test.ts
+++ b/tests/db/actions/respond-invitation.test.ts
@@ -152,6 +152,7 @@ describe("respondToInvitation - 受諾", () => {
       eventId: event.id,
       memberId,
       status: "accepted",
+      guestEmail: baseGuestInfo.guestEmail,
     });
     await addCompanion({ invitationId: target.id, name: "旧同伴" });
 
@@ -188,6 +189,7 @@ describe("respondToInvitation - 辞退", () => {
       status: "accepted",
       checkedIn: true,
       checkedInAt: 100,
+      guestEmail: baseGuestInfo.guestEmail,
     });
     await addCompanion({ invitationId: target.id });
 

--- a/tests/db/setup.ts
+++ b/tests/db/setup.ts
@@ -35,6 +35,23 @@ vi.mock("next/navigation", () => ({
   },
 }));
 
+// Server Action 内で next/server の `after` を使うが、テストはリクエスト
+// スコープを持たないため本物を呼ぶと throw する。コールバックを安全に
+// 実行できる no-op 相当に差し替える
+vi.mock("next/server", () => ({
+  after: (fn: () => unknown | Promise<unknown>) => {
+    Promise.resolve()
+      .then(() => fn())
+      .catch(() => {});
+  },
+}));
+
+// メール送信ユーティリティはテスト中は no-op で十分（送信の有無や引数を
+// 検証したいケースが出てきたら vi.fn().mockResolvedValue(...) に差し替える）
+vi.mock("@/lib/mailer", () => ({
+  sendMail: async () => {},
+}));
+
 vi.mock("@/lib/session", () => ({
   getSession: async () => {
     return (globalThis as { __mockSession?: unknown }).__mockSession ?? null;


### PR DESCRIPTION
## Summary
- 招待 RSVP の回答・編集・辞退の各経路で、ゲスト宛に確認メールを Resend 経由で送信
- メール本文に招待状リンクと操作内容（出席/辞退・同伴者）を記載
- プレーンテキスト、HTML 版は今回作らない

## 変更点
- 新規 `src/lib/mailer.ts`: Resend ラッパ。`RESEND_API_KEY` 未設定なら dev では宛先・件名のみログ、本番では throw
- 新規 `src/lib/emails/invitation-response.ts`: テキスト文面ビルダ
- 変更 `src/app/i/[token]/_actions.ts`: トランザクション成功後に `next/server` の `after()` で送信
- 追加環境変数: `RESEND_API_KEY` / `MAIL_FROM`（任意）/ `APP_PUBLIC_URL`

## code-review で対応した重要 4 件
1. **Spam relay 防止**: 編集時は `guestEmail` を前回入力と一致するときのみ受け付け、トークン保持者が任意宛先にメールを送れる経路を塞いだ
2. **Fire-and-forget 回避**: `void` Promise を `after()` に置き換え、serverless で Server Action 返却後に送信が打ち切られる挙動を防止
3. **ヘッダーインジェクション対策**: 件名生成時に event 名から CR/LF/Tab を除去
4. **本番ログの PII 漏洩防止**: `NODE_ENV=production` で API key 未設定なら throw。dev フォールバックも本文を出さず宛先・件名のみに

## Known issues（フォローで対応予定）
- `??` empty-string fallback (`APP_PUBLIC_URL` / `MAIL_FROM`) を `||` か空文字ガードに
- `mailer.ts` の `cachedClient` シングルトンが `RESEND_API_KEY` ローテーションを反映しない
- `prevStatus` をトランザクション前に読むため、並列回答で「初回 / 更新」の言い回しが食い違う可能性
- 同内容の連打で確認メールが複数届く（冪等性なし）
- `getBaseUrl` が `src/lib/auth.ts` と fallback chain が違い、preview で localhost リンクになる可能性
- `buildInvitationResponseMail` が将来 throw した場合に `revalidatePath` が走らない

## Test plan
- [x] \`pnpm type-check\` PASS
- [x] \`pnpm lint\` PASS
- [x] 文面ビルダの 4 ケース snapshot を確認（初回×出席/辞退、変更×出席/辞退）
- [x] dev server 経由で実招待リンクから「初回・出席・同伴者なし」「変更・辞退」を送信し、サーバーログに \`[mailer] would send\` が宛先・件名つきで出ることを確認
- [ ] preview デプロイで \`RESEND_API_KEY\` を空のまま \`/i/<token>\` を叩いて throw までの挙動を目視確認
- [ ] lull.live の Resend ドメイン認証（SPF/DKIM/DMARC）完了後に本番で実送信を確認

## 本番反映前に必要な作業
- lull.live ドメインを Resend ダッシュボードで認証（SPF / DKIM / DMARC を Vercel DNS に追加）。未認証のまま本番 deploy するとメール送信が Resend 側で 401/422 になり、確認メールは届きません

🤖 Generated with [Claude Code](https://claude.com/claude-code)