### PR TITLE
refactor(event): イベント詳細と招待状の日時表示を統一

### DIFF
--- a/src/app/_components/event-detail.tsx
+++ b/src/app/_components/event-detail.tsx
@@ -158,12 +158,14 @@ export function EventDetail({
             <dl className="grid gap-6 border-border/60 border-y py-6 md:grid-cols-3">
               <FactItem
                 icon={<CalendarBlank className="h-4 w-4" aria-hidden />}
-                label="開演"
-                value={formatDatetime(event.startDatetime)}
-                sub={
-                  event.openDatetime
-                    ? `開場 ${formatDatetime(event.openDatetime)}`
-                    : null
+                label="日時"
+                value={
+                  <div className="flex flex-col gap-1">
+                    {event.openDatetime && (
+                      <span>開場 {formatDatetime(event.openDatetime)}</span>
+                    )}
+                    <span>開演 {formatDatetime(event.startDatetime)}</span>
+                  </div>
                 }
               />
               <FactItem
@@ -348,8 +350,8 @@ function FactItem({
 }: {
   icon: ReactNode;
   label: string;
-  value: string;
-  sub?: string | null;
+  value: ReactNode;
+  sub?: ReactNode | null;
 }) {
   return (
     // biome-ignore lint/a11y/useSemanticElements: <dl> の子として <fieldset> は使えないため、name-value group のラッパとして div + role="group" を採用

--- a/src/app/i/[token]/page.tsx
+++ b/src/app/i/[token]/page.tsx
@@ -96,21 +96,14 @@ function EventInfoHeader({
             </span>
           )}
         </dd>
-        {event.openDatetime && (
-          <>
-            <dt className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
-              開場
-            </dt>
-            <dd className="text-sm tabular-nums">
-              {formatTime(event.openDatetime)}
-            </dd>
-          </>
-        )}
         <dt className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
-          開演
+          日時
         </dt>
-        <dd className="text-sm tabular-nums">
-          {formatTime(event.startDatetime)}
+        <dd className="flex flex-col gap-1 text-sm tabular-nums">
+          {event.openDatetime && (
+            <span>開場 {formatTime(event.openDatetime)}</span>
+          )}
+          <span>開演 {formatTime(event.startDatetime)}</span>
         </dd>
       </dl>
       <div className="animate-in fade-in slide-in-from-bottom-2 duration-700 delay-300 motion-reduce:animate-none motion-reduce:delay-0">


### PR DESCRIPTION
## Summary
- イベント詳細・招待状で「開演」ラベルを「日時」に変更
- 「開場 …」「開演 …」を同階層で縦並び表示にして頭を揃え、読みやすく

## 変更点
- `src/app/_components/event-detail.tsx`: `FactItem.value` を ReactNode 化し、日時セクションで開場/開演を同階層に表示（開場は `openDatetime` がある場合のみ）
- `src/app/i/[token]/page.tsx`: dt「開場」「開演」を dt「日時」に統合、dd 内で開場/開演を縦並びに

## Test plan
- [ ] イベント詳細ページで「日時」ラベル下に開場・開演が縦並びで表示される
- [ ] `openDatetime` が未設定のイベントで「開演」のみ表示される
- [ ] 招待状ページ `/i/[token]` で同様に表示される
- [ ] `pnpm type-check` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)