### PR TITLE
chore: mise.toml を削除

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,0 @@
-[tools]
-node = "lts"
-"npm:pnpm" = "11.1.3"


### PR DESCRIPTION
## 変更内容

`mise.toml` を削除した。

## なぜ

mise によるツールバージョン管理（`node = "lts"` / `pnpm 11.1.3`）を廃止し、各環境のバージョン管理に委ねる。

## レビュアーへの補足

- これまで mise で固定していた node / pnpm のバージョンが、今後は各自の手元の設定に委ねられる点に留意。
- `package.json` の `engines` や `packageManager` フィールドでの代替固定が必要かは別途検討。

🤖 Generated with [Claude Code](https://claude.com/claude-code)