### PR TITLE
feat(program): 演目の詳細をモーダルで表示

### DIFF
--- a/src/app/_components/program-detail.stories.tsx
+++ b/src/app/_components/program-detail.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import {
+  ResponsiveModal,
+  ResponsiveModalContent,
+  ResponsiveModalHeader,
+  ResponsiveModalTitle,
+} from "@/components/ui/responsive-modal";
+import type { ProgramWithPerformers } from "@/lib/queries/programs";
+import { ProgramDetail } from "./program-detail";
+
+const meta = {
+  component: ProgramDetail,
+  render: (args) => (
+    <ResponsiveModal open size="sm">
+      <ResponsiveModalContent>
+        <ResponsiveModalHeader>
+          <ResponsiveModalTitle>プログラムの詳細</ResponsiveModalTitle>
+        </ResponsiveModalHeader>
+        <ProgramDetail {...args} />
+      </ResponsiveModalContent>
+    </ResponsiveModal>
+  ),
+} satisfies Meta<typeof ProgramDetail>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const performance: ProgramWithPerformers = {
+  id: "p1",
+  sortOrder: 1,
+  type: "performance",
+  scheduledTime: "14:30",
+  estimatedDuration: 8,
+  note: "ピアノは事前に調律済み。\n楽譜はこちら https://example.com/scores/nocturne を参照。\n転換に1分ほしいです。",
+  performers: [
+    { id: "pp1", memberId: "m1", displayName: "山田花子" },
+    { id: "pp2", memberId: "m2", displayName: "田中太郎" },
+  ],
+  pieces: [
+    {
+      id: "pc1",
+      sortOrder: 1,
+      title: "ノクターン 第2番",
+      composer: "F. Chopin",
+    },
+    { id: "pc2", sortOrder: 2, title: "愛の夢 第3番", composer: "F. Liszt" },
+  ],
+};
+
+export const Performance: Story = {
+  args: { program: performance },
+};
+
+export const NonPerformance: Story = {
+  args: {
+    program: {
+      id: "p2",
+      sortOrder: 2,
+      type: "intermission",
+      scheduledTime: null,
+      estimatedDuration: 10,
+      note: "ロビーで飲み物を提供します。",
+      performers: [],
+      pieces: [{ id: "pc3", sortOrder: 1, title: "休憩", composer: null }],
+    },
+  },
+};

--- a/src/app/_components/program-detail.tsx
+++ b/src/app/_components/program-detail.tsx
@@ -1,0 +1,120 @@
+import { Clock, Hourglass } from "@phosphor-icons/react";
+import { Fragment } from "react";
+import type { ProgramWithPerformers } from "@/lib/queries/programs";
+
+type ProgramDetailProps = {
+  program: ProgramWithPerformers;
+};
+
+// 備考テキスト中の http(s) URL をリンクに変換する。
+// 末尾に付きがちな句読点・閉じ括弧は URL から除外する。
+const URL_PATTERN = /(https?:\/\/[^\s]+)/g;
+const TRAILING_PUNCTUATION = /[.,;:!?。、）)\]】」』]+$/;
+
+function renderNote(note: string) {
+  let offset = 0;
+  // 分割により URL 部分は奇数インデックスに入る。
+  // key には文字位置を使い、同一文字列が複数あっても安定・一意にする。
+  return note.split(URL_PATTERN).map((part, index) => {
+    const key = offset;
+    offset += part.length;
+
+    if (index % 2 === 0) {
+      return <Fragment key={key}>{part}</Fragment>;
+    }
+
+    const trailing = part.match(TRAILING_PUNCTUATION)?.[0] ?? "";
+    const url = trailing ? part.slice(0, -trailing.length) : part;
+
+    return (
+      <Fragment key={key}>
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="break-all text-foreground underline underline-offset-2 transition-colors hover:text-muted-foreground"
+        >
+          {url}
+        </a>
+        {trailing}
+      </Fragment>
+    );
+  });
+}
+
+export function ProgramDetail({ program }: ProgramDetailProps) {
+  const hasMeta =
+    Boolean(program.scheduledTime) || program.estimatedDuration != null;
+
+  return (
+    <div className="flex flex-col gap-6 pt-2">
+      <div className="flex flex-col gap-2">
+        {program.type === "performance" ? (
+          <>
+            {program.performers.length > 0 && (
+              <span className="font-medium tracking-wide">
+                {program.performers.map((p) => p.displayName).join(", ")}
+              </span>
+            )}
+            <div className="mt-1 flex flex-col gap-2 border-l border-border/50 pl-3">
+              {program.pieces.map((piece) => (
+                <div key={piece.id} className="flex flex-col">
+                  <span className="text-sm">{piece.title}</span>
+                  {piece.composer && (
+                    <span className="text-xs text-muted-foreground/70">
+                      {piece.composer}
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+          </>
+        ) : (
+          <span className="tracking-wide text-muted-foreground">
+            {program.pieces[0]?.title}
+          </span>
+        )}
+      </div>
+
+      {hasMeta && (
+        <dl className="flex gap-8 border-y border-border/40 py-3">
+          {program.scheduledTime && (
+            <div className="flex flex-col gap-1">
+              <dt className="flex items-center gap-1.5 text-xs tracking-wide text-muted-foreground">
+                <Clock size={13} />
+                予定時刻
+              </dt>
+              <dd className="text-sm tabular-nums">
+                {program.scheduledTime}〜
+              </dd>
+            </div>
+          )}
+          {program.estimatedDuration != null && (
+            <div className="flex flex-col gap-1">
+              <dt className="flex items-center gap-1.5 text-xs tracking-wide text-muted-foreground">
+                <Hourglass size={13} />
+                所要時間
+              </dt>
+              <dd className="text-sm tabular-nums">
+                {program.estimatedDuration}分
+              </dd>
+            </div>
+          )}
+        </dl>
+      )}
+
+      <div className="flex flex-col gap-2">
+        <span className="text-xs tracking-wide text-muted-foreground">
+          備考
+        </span>
+        {program.note?.trim() ? (
+          <p className="whitespace-pre-wrap text-sm leading-relaxed">
+            {renderNote(program.note)}
+          </p>
+        ) : (
+          <p className="text-sm text-muted-foreground/60">備考はありません</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/_components/program-list.stories.tsx
+++ b/src/app/_components/program-list.stories.tsx
@@ -9,6 +9,7 @@ const meta = {
     onReorder: fn(async () => null),
     onDelete: fn(async () => null),
     onEdit: fn(),
+    onShowDetail: fn(),
     onAdd: fn(),
   },
 } satisfies Meta<typeof ProgramList>;
@@ -85,7 +86,7 @@ const samplePrograms: ProgramWithPerformers[] = [
     type: "performance",
     scheduledTime: "14:40",
     estimatedDuration: 15,
-    note: null,
+    note: "ピアノは事前に調律済み。\n転換に1分ほしいです。",
     performers: [
       { id: "pp3", memberId: "m1", displayName: "田中太郎" },
       { id: "pp4", memberId: "m2", displayName: "鈴木花子" },

--- a/src/app/_components/program-list.tsx
+++ b/src/app/_components/program-list.tsx
@@ -2,6 +2,7 @@
 
 import {
   DotsSixVertical,
+  Note,
   PencilSimple,
   Plus,
   Trash,
@@ -44,6 +45,7 @@ type ProgramListProps = {
     programId: string,
   ) => Promise<{ error: string } | null>;
   onEdit: (program: ProgramWithPerformers) => void;
+  onShowDetail: (program: ProgramWithPerformers) => void;
   onAdd?: () => void;
 };
 
@@ -54,6 +56,7 @@ export function ProgramList({
   onReorder,
   onDelete,
   onEdit,
+  onShowDetail,
   onAdd,
 }: ProgramListProps) {
   const [programs, setPrograms] =
@@ -194,6 +197,7 @@ export function ProgramList({
                 selected={selectedId === program.id}
                 onSelect={handleSelect}
                 onEdit={onEdit}
+                onShowDetail={onShowDetail}
                 onDelete={handleDelete}
               />
             );
@@ -212,6 +216,7 @@ type ProgramRowProps = {
   selected: boolean;
   onSelect: (id: string) => void;
   onEdit: (program: ProgramWithPerformers) => void;
+  onShowDetail: (program: ProgramWithPerformers) => void;
   onDelete: (programId: string) => void;
 };
 
@@ -223,6 +228,7 @@ function ProgramRow({
   selected,
   onSelect,
   onEdit,
+  onShowDetail,
   onDelete,
 }: ProgramRowProps) {
   const dragControls = useDragControls();
@@ -240,6 +246,8 @@ function ProgramRow({
           .filter(Boolean)
           .join(" · ")
       : null;
+
+  const hasNote = Boolean(program.note?.trim());
 
   const isReorder = mode === "reorder";
   const interactive = canModify && mode === "view";
@@ -359,6 +367,21 @@ function ProgramRow({
             style={{ overflow: "hidden" }}
           >
             <div className="flex items-center justify-end gap-1 border-t border-border/40 bg-background/40 px-3 py-2">
+              {hasNote && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="gap-1.5"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onShowDetail(program);
+                  }}
+                >
+                  <Note size={14} />
+                  詳細
+                </Button>
+              )}
+
               <Button
                 variant="ghost"
                 size="sm"

--- a/src/app/_components/program-management.tsx
+++ b/src/app/_components/program-management.tsx
@@ -20,6 +20,7 @@ import {
   deleteProgram,
   reorderPrograms,
 } from "../(main)/events/[eventId]/programs/_actions";
+import { ProgramDetail } from "./program-detail";
 import { ProgramForm } from "./program-form";
 import { ProgramList } from "./program-list";
 
@@ -37,6 +38,7 @@ type ProgramManagementProps = {
 type DialogState =
   | { mode: "add" }
   | { mode: "edit"; program: ProgramWithPerformers }
+  | { mode: "detail"; program: ProgramWithPerformers }
   | null;
 
 export function ProgramManagement({
@@ -84,6 +86,7 @@ export function ProgramManagement({
         onReorder={reorderPrograms}
         onDelete={deleteProgram}
         onEdit={(program) => setDialog({ mode: "edit", program })}
+        onShowDetail={(program) => setDialog({ mode: "detail", program })}
         onAdd={canModify ? openAdd : undefined}
       />
 
@@ -92,15 +95,21 @@ export function ProgramManagement({
         onOpenChange={(open) => {
           if (!open) close();
         }}
+        size={dialog?.mode === "detail" ? "sm" : "md"}
       >
         <ResponsiveModalContent>
           <ResponsiveModalHeader>
             <ResponsiveModalTitle>
               {dialog?.mode === "edit"
                 ? "プログラムを編集"
-                : "プログラムを追加"}
+                : dialog?.mode === "detail"
+                  ? "プログラムの詳細"
+                  : "プログラムを追加"}
             </ResponsiveModalTitle>
           </ResponsiveModalHeader>
+          {dialog?.mode === "detail" && (
+            <ProgramDetail program={dialog.program} />
+          )}
           {dialog?.mode === "add" && (
             <ProgramForm
               eventId={event.id}


### PR DESCRIPTION
## 概要

プログラム編集画面で、これまで入力はできても表示する場所が無かった演目の詳細（特に備考）を、モーダルで閲覧できるようにする。

行の展開パネルに、編集・削除と並べて「詳細」ボタンを追加。押すと演目の出演者・曲目・予定時刻/所要時間・備考をまとめたモーダル（デスクトップは Dialog / モバイルは下からの Sheet）を開く。

## 変更点

- **`ProgramDetail` コンポーネント追加**: 出演者・曲目・予定時刻/所要時間・備考を読み取り専用で表示。アプリの editorial なトーン（明朝・細罫・`tabular-nums`）に合わせた構成
- **備考内 URL のリンク化**: `http(s)://…` を `target=_blank` + `rel=noopener noreferrer` のリンクに変換。末尾の句読点・閉じ括弧は URL から除外し、長い URL は折り返す
- **「詳細」ボタン**: 備考がある演目の展開パネルにのみ表示（行には既に出演者・曲目・時刻が出ているため、モーダルが主に足すのは備考）
- **表示状態の集約**: `program-management` の `DialogState` に `detail` モードを追加し、既存の `ResponsiveModal` を再利用
- **Storybook**: `ProgramDetail` のストーリー（パフォーマンス/非パフォーマンス・URL リンク含む）を追加、`program-list` のストーリーに `onShowDetail` と備考付きサンプルを補完

## コミット構成

1. `feat(program)`: `ProgramDetail` コンポーネント（URL リンク化込み）
2. `feat(program)`: 一覧の詳細ボタン＋モーダル配線
3. `test(program)`: Storybook ストーリー

## 確認

- `pnpm type-check` / `biome check` パス（pre-commit の lefthook も通過）
- preview（emulator 認証）でプログラム管理画面を実機確認: 備考のある演目にのみ詳細ボタンが出る → モーダルが開く → 備考内 URL がリンク表示される、を確認
- Storybook で詳細モーダルの見た目を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)