### PR TITLE
chore: add fnox secret config (providers only)

### DIFF
--- a/fnox.toml
+++ b/fnox.toml
@@ -1,0 +1,8 @@
+# fnox secrets config
+# secret 値は age 公開鍵で暗号化された暗号文（git コミット可）。
+# 復号鍵は macOS keychain (service=fnox, account=age-key) から auth_command で取得。
+
+[providers]
+age = { type = "age", recipients = ["age1rvnrau0swu4tds583lrzgurxpv20ylvku5tgr2tg3jnqxe3gndfs0m6jp0"], auth_command = "security find-generic-password -s fnox -a age-key -w" }
+
+[secrets]


### PR DESCRIPTION
fnox の provider 設定（age + keychain）を追加。lull はまだ実 secret 未投入で providers のみ。

- honno-naruki / interlink と同一の age 公開鍵・keychain `auth_command`
- `.mcp.json` は当リポでは gitignore 対象のためローカル配置（コミット対象外）
- 実 secret は今後同手順（stdin/パイプ投入）で追加可能

動作確認: dev server 起動（activate 経由、HTTP 200）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)