### PR TITLE
ci: gh-pages ブランチの Vercel デプロイを無効化

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,8 @@
 {
-  "buildCommand": "pnpm build"
+  "buildCommand": "pnpm build",
+  "git": {
+    "deploymentEnabled": {
+      "gh-pages": false
+    }
+  }
 }


### PR DESCRIPTION
## 概要

VRT レポートを gh-pages へ publish する push で Vercel の deployment が毎回トリガーされていたため、`vercel.json` の `git.deploymentEnabled` で gh-pages ブランチのみデプロイを無効化する。

## 背景

`#196` で導入した `.github/workflows/vrt.yml` が、PR ごとに `git push --force origin gh-pages` で VRT レポートを GitHub Pages に publish している。この push のたびに Vercel が gh-pages ブランチのデプロイを走らせてしまうため、レポート用ブランチに対する不要なデプロイを止める。

## 変更内容

`vercel.json` に以下を追加:

```json
"git": {
  "deploymentEnabled": {
    "gh-pages": false
  }
}
```

- gh-pages ブランチへの push では deployment が作成されなくなる
- main / PR の preview デプロイには影響しない

## 補足

`git.deploymentEnabled` は Vercel が production ブランチ（main）の `vercel.json` を読んで適用する想定。main マージ後も gh-pages の push でデプロイが走る場合は、ダッシュボードの Ignored Build Step 併用を検討する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)