### PR TITLE
PWA インストールプロンプトとローカル開発ガイドを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## プロジェクト概要
 
-Lull（ラル）— 発表会の招待・座席・当日体験を一つに繋ぐ Web アプリケーション。管理者・出演者・ゲストの 3 ロール構成。詳細は README.md と ARCHITECTURE.md を参照。
+Lull（ラル）— 発表会の招待・座席・当日体験を一つに繋ぐ Web アプリケーション。管理者・出演者・ゲストの 3 ロール構成。詳細は README.md と ARCHITECTURE.md を参照。ローカル環境の構築手順は docs/local-dev-guide.md を参照。
 
 ## コマンド
 

--- a/docs/local-dev-guide.md
+++ b/docs/local-dev-guide.md
@@ -1,0 +1,89 @@
+# ローカル開発ガイド
+
+## セットアップ
+
+### 1. 依存インストール
+
+```bash
+pnpm install
+```
+
+### 2. `.env.local` を作成
+
+`.env.example` をコピーして最低限の値を埋める。
+
+```bash
+cp .env.example .env.local
+```
+
+必須の設定値:
+
+| 変数 | 値 | 備考 |
+|---|---|---|
+| `BETTER_AUTH_SECRET` | 任意の文字列 | dev 用なので適当でよい |
+| `BETTER_AUTH_URL` | `http://localhost:3000` | |
+| `GOOGLE_CLIENT_ID` | 本物の値 or `emulate-client` | エミュレータ利用時は後者 |
+| `GOOGLE_CLIENT_SECRET` | 本物の値 or `emulate-secret` | 同上 |
+| `APP_PUBLIC_URL` | `http://localhost:3000` | |
+
+### 3. DB を初期化
+
+ローカルでは SQLite ファイル (`local.db`) が自動作成される。`TURSO_DATABASE_URL` 未設定時のデフォルト。
+
+```bash
+pnpm db:push
+```
+
+`db:push` はスキーマを DB に直接反映する（マイグレーションファイルを生成せずに済む）。ローカル開発ではこれで十分。
+
+### 4. 開発サーバー起動
+
+```bash
+pnpm dev
+```
+
+## Google OAuth エミュレータ
+
+本物の Google OAuth クレデンシャルがなくても、エミュレータでログインできる。
+
+### 有効化条件
+
+`.env.local` に以下を **両方** 設定する:
+
+```
+GOOGLE_CLIENT_ID=emulate-client
+GOOGLE_CLIENT_SECRET=emulate-secret
+NEXT_PUBLIC_VERCEL_ENV=preview
+```
+
+`NEXT_PUBLIC_VERCEL_ENV=preview` がないとエミュレータが有効にならない。`isPreview` 判定（`src/lib/env.ts`）がこの値を見ている。
+
+### 動作
+
+サインインボタンを押すと、本物の Google ログイン画面の代わりにエミュレータ画面が表示される。任意のメールアドレス・名前でログインできる。
+
+## よくあるハマりどころ
+
+### DB 関連のエラーが出る
+
+`.env.local` が存在しないか、DB が初期化されていない。
+
+```bash
+# .env.local があるか確認
+ls -la .env.local
+
+# DB を初期化
+pnpm db:push
+```
+
+### エミュレータが動かない / 本物の Google 画面が出る
+
+`NEXT_PUBLIC_VERCEL_ENV=preview` が `.env.local` に入っているか確認。追加した場合は dev サーバーの再起動が必要（`NEXT_PUBLIC_*` はビルド時に埋め込まれるため）。
+
+### worktree で動かない
+
+worktree には `.env.local` や `local.db` が共有されない（gitignore 対象のため）。worktree ごとに `.env.local` を作成し、`pnpm db:push` を実行する。
+
+### Resend（メール送信）のエラー
+
+`RESEND_API_KEY` 未設定でも dev では動く。実送信はせず、宛先と件名のみ `console.info` に出力される。`NODE_ENV=production` で未設定の場合のみエラーになる。

--- a/src/app/(main)/dashboard/page.tsx
+++ b/src/app/(main)/dashboard/page.tsx
@@ -1,5 +1,6 @@
 import { CreateEventDialog } from "@/app/_components/create-event-dialog";
 import { EventCard } from "@/app/_components/event-card";
+import { PwaInstallBanner } from "@/components/pwa-install-banner";
 import { getEventsByUserId } from "@/lib/queries/events";
 import { requireSession } from "@/lib/session";
 
@@ -12,6 +13,10 @@ export default async function DashboardPage() {
       <div className="mb-10 flex items-center justify-between">
         <h1 className="text-2xl font-light tracking-wide">マイイベント</h1>
         <CreateEventDialog />
+      </div>
+
+      <div className="-mt-4 mb-6 empty:hidden">
+        <PwaInstallBanner dismissible={false} />
       </div>
 
       {events.length === 0 ? (

--- a/src/app/_components/invitation-response-form.tsx
+++ b/src/app/_components/invitation-response-form.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
 import { respondToInvitation } from "@/app/i/[token]/_actions";
+import { PwaInstallBanner } from "@/components/pwa-install-banner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -47,6 +48,7 @@ export function InvitationResponseForm({
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [isPending, startTransition] = useTransition();
   const [isOpen, setIsOpen] = useState(!isUpdate);
+  const [hasJustResponded, setHasJustResponded] = useState(false);
 
   const handleAddCompanion = () => {
     if (companions.length >= 4) return;
@@ -83,6 +85,7 @@ export function InvitationResponseForm({
         if (result.error) toast.error(result.error);
       } else {
         toast.success("回答を受け取りました");
+        if (!isUpdate) setHasJustResponded(true);
         setIsOpen(false);
       }
     });
@@ -106,6 +109,7 @@ export function InvitationResponseForm({
         >
           回答を変更する
         </button>
+        {hasJustResponded && <PwaInstallBanner dismissId="guest" />}
       </div>
     );
   }

--- a/src/app/i/[token]/page.tsx
+++ b/src/app/i/[token]/page.tsx
@@ -8,6 +8,7 @@ import { InvitationProgramView } from "@/app/_components/invitation-program-view
 import { InvitationResponseForm } from "@/app/_components/invitation-response-form";
 import { QrCode } from "@/app/_components/qr-code";
 import { VenueLink } from "@/app/_components/venue-link";
+import { SaveGuestToken } from "@/components/guest-token-store";
 import type { EventStatus } from "@/db/schema";
 import { formatDate, formatDatetime, formatTime } from "@/lib/format";
 import { getInvitationByToken } from "@/lib/queries/invitations";
@@ -381,6 +382,7 @@ export default async function InvitationResponsePage(
 
   return (
     <GuestShell>
+      <SaveGuestToken token={token} />
       <EventInfoHeader
         event={event}
         inviterName={invitation.inviterDisplayName}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { SignInButton } from "@/app/_components/sign-in-button";
+import { GuestInvitationLink } from "@/components/guest-invitation-link";
 import { getSession, validateReturnTo } from "@/lib/session";
 
 export default async function Page(props: PageProps<"/">) {
@@ -19,6 +20,7 @@ export default async function Page(props: PageProps<"/">) {
       <p className="text-sm leading-relaxed text-muted-foreground">
         ひとつの舞台を、もっとあたたかく
       </p>
+      <GuestInvitationLink />
       <SignInButton callbackURL={callbackURL} />
     </div>
   );

--- a/src/components/guest-invitation-link.tsx
+++ b/src/components/guest-invitation-link.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { getGuestToken } from "@/components/guest-token-store";
+
+export function GuestInvitationLink() {
+  const [token, setToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    setToken(getGuestToken());
+  }, []);
+
+  if (!token) return null;
+
+  return (
+    <Link
+      href={`/i/${token}`}
+      className="rounded-sm px-1 py-1 text-sm text-muted-foreground underline underline-offset-4 transition-colors hover:text-foreground"
+    >
+      招待状を見る
+    </Link>
+  );
+}

--- a/src/components/guest-token-store.tsx
+++ b/src/components/guest-token-store.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useEffect } from "react";
+
+const STORAGE_KEY = "lull-guest-token";
+
+export function SaveGuestToken({ token }: { token: string }) {
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, token);
+  }, [token]);
+
+  return null;
+}
+
+export function getGuestToken(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem(STORAGE_KEY);
+}

--- a/src/components/pwa-install-banner.tsx
+++ b/src/components/pwa-install-banner.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { Export, Plus } from "@phosphor-icons/react";
+import { useEffect, useState } from "react";
+import { usePwaInstall } from "@/hooks/use-pwa-install";
+
+function getDismissKey(id: string) {
+  return `lull-pwa-dismissed-${id}`;
+}
+
+type PwaInstallBannerProps = {
+  dismissId?: string;
+  dismissible?: boolean;
+};
+
+export function PwaInstallBanner({
+  dismissId = "default",
+  dismissible = true,
+}: PwaInstallBannerProps) {
+  const { hasNativeInstall, showManualGuide, isInstalled, promptInstall } =
+    usePwaInstall();
+
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    if (dismissible) {
+      setDismissed(localStorage.getItem(getDismissKey(dismissId)) === "1");
+    }
+  }, [dismissible, dismissId]);
+
+  if (isInstalled) return null;
+  if (!hasNativeInstall && !showManualGuide) return null;
+  if (dismissible && dismissed) return null;
+
+  const handleDismiss = () => {
+    localStorage.setItem(getDismissKey(dismissId), "1");
+    setDismissed(true);
+  };
+
+  return (
+    <div
+      data-testid="pwa-install-banner"
+      className="flex flex-col gap-3 rounded-sm border border-border/50 px-5 py-4"
+    >
+      {hasNativeInstall ? (
+        <NativeInstallContent
+          onInstall={promptInstall}
+          onDismiss={dismissible ? handleDismiss : undefined}
+        />
+      ) : (
+        <ManualGuideContent
+          onDismiss={dismissible ? handleDismiss : undefined}
+        />
+      )}
+    </div>
+  );
+}
+
+function NativeInstallContent({
+  onInstall,
+  onDismiss,
+}: {
+  onInstall: () => void;
+  onDismiss?: () => void;
+}) {
+  return (
+    <>
+      <p className="text-sm leading-relaxed text-muted-foreground">
+        ホーム画面に追加すると、当日チケットにすぐアクセスできます
+      </p>
+      <div className="flex items-center gap-4">
+        <button
+          type="button"
+          onClick={onInstall}
+          className="rounded-sm bg-foreground px-4 py-2 text-xs tracking-[0.1em] text-background transition-colors hover:bg-foreground/90"
+        >
+          ホーム画面に追加
+        </button>
+        {onDismiss && <DismissButton onClick={onDismiss} />}
+      </div>
+    </>
+  );
+}
+
+function ManualGuideContent({ onDismiss }: { onDismiss?: () => void }) {
+  const isIos =
+    typeof navigator !== "undefined" &&
+    /iPad|iPhone|iPod/.test(navigator.userAgent);
+
+  return (
+    <>
+      <p className="text-sm leading-relaxed text-muted-foreground">
+        ホーム画面に追加すると、当日チケットにすぐアクセスできます
+      </p>
+      <div className="flex flex-col gap-2 text-xs text-muted-foreground">
+        {isIos ? (
+          <>
+            <span className="inline-flex items-center gap-1.5">
+              <Export className="size-3.5 shrink-0" />
+              共有ボタンをタップ
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <Plus className="size-3.5 shrink-0" />
+              「ホーム画面に追加」を選択
+            </span>
+          </>
+        ) : (
+          <span>
+            ブラウザのメニューから「ホーム画面に追加」を選択してください
+          </span>
+        )}
+      </div>
+      {onDismiss && (
+        <div>
+          <DismissButton onClick={onDismiss} />
+        </div>
+      )}
+    </>
+  );
+}
+
+function DismissButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="rounded-sm px-1 py-1 text-xs text-muted-foreground underline underline-offset-4 transition-colors hover:text-foreground"
+    >
+      あとで
+    </button>
+  );
+}

--- a/src/hooks/use-pwa-install.ts
+++ b/src/hooks/use-pwa-install.ts
@@ -1,0 +1,90 @@
+"use client";
+
+import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
+
+type BeforeInstallPromptEvent = Event & {
+  prompt(): Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+};
+
+let deferredPrompt: BeforeInstallPromptEvent | null = null;
+const listeners = new Set<() => void>();
+
+function notify() {
+  for (const fn of listeners) fn();
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("beforeinstallprompt", (e) => {
+    e.preventDefault();
+    deferredPrompt = e as BeforeInstallPromptEvent;
+    notify();
+  });
+
+  window.addEventListener("appinstalled", () => {
+    deferredPrompt = null;
+    notify();
+  });
+}
+
+function subscribePrompt(onChange: () => void) {
+  listeners.add(onChange);
+  return () => {
+    listeners.delete(onChange);
+  };
+}
+
+export function usePwaInstall() {
+  const hasNativeInstall = useSyncExternalStore(
+    subscribePrompt,
+    () => deferredPrompt !== null,
+    () => false,
+  );
+
+  const subscribeStandalone = useCallback((onChange: () => void) => {
+    const mql = window.matchMedia("(display-mode: standalone)");
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+
+  const isInstalled = useSyncExternalStore(
+    subscribeStandalone,
+    () =>
+      window.matchMedia("(display-mode: standalone)").matches ||
+      ("standalone" in navigator &&
+        !!(navigator as Record<string, unknown>).standalone),
+    () => false,
+  );
+
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    setIsReady(true);
+  }, []);
+
+  const promptInstall = useCallback(async () => {
+    if (!deferredPrompt) return;
+    await deferredPrompt.prompt();
+    const { outcome } = await deferredPrompt.userChoice;
+    if (outcome === "accepted") {
+      deferredPrompt = null;
+      notify();
+    }
+  }, []);
+
+  if (!isReady || isInstalled) {
+    return {
+      hasNativeInstall: false,
+      showManualGuide: false,
+      isInstalled,
+      promptInstall,
+    } as const;
+  }
+
+  return {
+    hasNativeInstall,
+    showManualGuide: !hasNativeInstall,
+    isInstalled,
+    promptInstall,
+  } as const;
+}


### PR DESCRIPTION
## Summary
- ゲスト（出欠回答直後）と出演者（ダッシュボード常時）にホーム画面追加バナーを追加
- `beforeinstallprompt` 非対応環境ではブラウザメニュー操作の手順を案内
- ゲストの招待トークンを localStorage に保存し、PWA 起動時に招待状へ戻れる導線をホームに追加
- ローカル開発の手順書を `docs/local-dev-guide.md` に整理し、CLAUDE.md から参照

## 新規ファイル
- `src/hooks/use-pwa-install.ts` — module scope で `beforeinstallprompt` をキャプチャする PWA インストール状態フック
- `src/components/pwa-install-banner.tsx` — ネイティブ / マニュアルガイド切替のバナー UI
- `src/components/guest-token-store.tsx` — 招待トークンの localStorage 保存・取得
- `src/components/guest-invitation-link.tsx` — ホームページの「招待状を見る」リンク
- `docs/local-dev-guide.md` — `.env.local` 設定、DB 初期化、OAuth エミュレータの有効化手順

## Test plan
- [x] `pnpm type-check` pass
- [x] `pnpm build` pass
- [x] 招待ページで出欠回答後に PWA バナーが表示される（playwright-cli で確認）
- [x] ダッシュボードに PWA バナーが常時表示される
- [x] localStorage にトークンが保存され、ホームに「招待状を見る」リンクが出る
- [ ] ネイティブインストールプロンプト表示（実機確認）
- [ ] standalone モード時にバナー非表示（実機確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)