### PR TITLE
PWA バナーのテキスト出し分けと視認性改善

### DIFF
--- a/src/app/(main)/dashboard/page.tsx
+++ b/src/app/(main)/dashboard/page.tsx
@@ -16,7 +16,7 @@ export default async function DashboardPage() {
       </div>
 
       <div className="-mt-4 mb-6 empty:hidden">
-        <PwaInstallBanner dismissible={false} />
+        <PwaInstallBanner dismissible={false} variant="member" />
       </div>
 
       {events.length === 0 ? (

--- a/src/components/pwa-install-banner.tsx
+++ b/src/components/pwa-install-banner.tsx
@@ -11,11 +11,18 @@ function getDismissKey(id: string) {
 type PwaInstallBannerProps = {
   dismissId?: string;
   dismissible?: boolean;
+  variant?: "guest" | "member";
 };
+
+const descriptions = {
+  guest: "ホーム画面に追加すると、当日チケットにすぐアクセスできます",
+  member: "ホーム画面に追加すると、イベント管理にすぐアクセスできます",
+} as const;
 
 export function PwaInstallBanner({
   dismissId = "default",
   dismissible = true,
+  variant = "guest",
 }: PwaInstallBannerProps) {
   const { hasNativeInstall, showManualGuide, isInstalled, promptInstall } =
     usePwaInstall();
@@ -37,6 +44,8 @@ export function PwaInstallBanner({
     setDismissed(true);
   };
 
+  const description = descriptions[variant];
+
   return (
     <div
       data-testid="pwa-install-banner"
@@ -44,11 +53,13 @@ export function PwaInstallBanner({
     >
       {hasNativeInstall ? (
         <NativeInstallContent
+          description={description}
           onInstall={promptInstall}
           onDismiss={dismissible ? handleDismiss : undefined}
         />
       ) : (
         <ManualGuideContent
+          description={description}
           onDismiss={dismissible ? handleDismiss : undefined}
         />
       )}
@@ -57,16 +68,18 @@ export function PwaInstallBanner({
 }
 
 function NativeInstallContent({
+  description,
   onInstall,
   onDismiss,
 }: {
+  description: string;
   onInstall: () => void;
   onDismiss?: () => void;
 }) {
   return (
     <>
       <p className="text-sm leading-relaxed text-muted-foreground">
-        ホーム画面に追加すると、当日チケットにすぐアクセスできます
+        {description}
       </p>
       <div className="flex items-center gap-4">
         <button
@@ -82,7 +95,13 @@ function NativeInstallContent({
   );
 }
 
-function ManualGuideContent({ onDismiss }: { onDismiss?: () => void }) {
+function ManualGuideContent({
+  description,
+  onDismiss,
+}: {
+  description: string;
+  onDismiss?: () => void;
+}) {
   const isIos =
     typeof navigator !== "undefined" &&
     /iPad|iPhone|iPod/.test(navigator.userAgent);
@@ -90,7 +109,7 @@ function ManualGuideContent({ onDismiss }: { onDismiss?: () => void }) {
   return (
     <>
       <p className="text-sm leading-relaxed text-muted-foreground">
-        ホーム画面に追加すると、当日チケットにすぐアクセスできます
+        {description}
       </p>
       <div className="flex flex-col gap-2 text-xs text-muted-foreground">
         {isIos ? (

--- a/src/components/pwa-install-banner.tsx
+++ b/src/components/pwa-install-banner.tsx
@@ -49,7 +49,7 @@ export function PwaInstallBanner({
   return (
     <div
       data-testid="pwa-install-banner"
-      className="flex flex-col gap-3 rounded-sm border border-border/50 px-5 py-4"
+      className="flex flex-col gap-3 rounded-sm bg-muted px-5 py-4"
     >
       {hasNativeInstall ? (
         <NativeInstallContent


### PR DESCRIPTION
## Summary
- バナーテキストをゲスト/メンバーで出し分け（ゲスト: 「当日チケット」、メンバー: 「イベント管理」）
- `border-border/50` では背景に溶けて見えなかったため `bg-muted` に変更し視認性を確保

## Test plan
- [x] ダッシュボードで「イベント管理にすぐアクセスできます」と表示される
- [x] ゲスト招待ページでは「当日チケットにすぐアクセスできます」のまま
- [x] `bg-muted` で背景との色差が認識できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)