### PR TITLE
fix: PWA インストールバナーを SSR 時点で描画する

### DIFF
--- a/src/components/pwa-install-banner.tsx
+++ b/src/components/pwa-install-banner.tsx
@@ -2,6 +2,7 @@
 
 import { Export, Plus } from "@phosphor-icons/react";
 import { useEffect, useState } from "react";
+import { useIsIos } from "@/hooks/use-is-ios";
 import { usePwaInstall } from "@/hooks/use-pwa-install";
 
 function getDismissKey(id: string) {
@@ -102,9 +103,7 @@ function ManualGuideContent({
   description: string;
   onDismiss?: () => void;
 }) {
-  const isIos =
-    typeof navigator !== "undefined" &&
-    /iPad|iPhone|iPod/.test(navigator.userAgent);
+  const isIos = useIsIos();
 
   return (
     <>

--- a/src/hooks/use-is-ios.ts
+++ b/src/hooks/use-is-ios.ts
@@ -1,0 +1,13 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useIsIos() {
+  const [isIos, setIsIos] = useState(false);
+
+  useEffect(() => {
+    setIsIos(/iPad|iPhone|iPod/.test(navigator.userAgent));
+  }, []);
+
+  return isIos;
+}

--- a/src/hooks/use-pwa-install.ts
+++ b/src/hooks/use-pwa-install.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 
 type BeforeInstallPromptEvent = Event & {
   prompt(): Promise<void>;
@@ -56,12 +56,6 @@ export function usePwaInstall() {
     () => false,
   );
 
-  const [isReady, setIsReady] = useState(false);
-
-  useEffect(() => {
-    setIsReady(true);
-  }, []);
-
   const promptInstall = useCallback(async () => {
     if (!deferredPrompt) return;
     await deferredPrompt.prompt();
@@ -72,7 +66,7 @@ export function usePwaInstall() {
     }
   }, []);
 
-  if (!isReady || isInstalled) {
+  if (isInstalled) {
     return {
       hasNativeInstall: false,
       showManualGuide: false,


### PR DESCRIPTION
## Summary
- `usePwaInstall` の `isReady` ゲートを除去し、SSR 時点でバナーを描画するよう修正
- `ManualGuideContent` の iOS 判定を `useIsIos` フックに分離し hydration mismatch を回避

## Background
`isReady` (useState + useEffect) が SSR〜hydration 初回で `showManualGuide: false` を返し、バナーが null になっていた。`useSyncExternalStore` のサーバースナップショットで未インストール状態は判定できるため、`isReady` による遅延は不要。

## Test plan
- [ ] 未インストール状態のブラウザで `/dashboard` を開き、インストール誘導バナーが表示される
- [ ] PWA インストール済みの状態でバナーが表示されない
- [ ] iOS Safari でシェアボタン経由の手順が表示される
- [ ] `pnpm build` が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)