### PR TITLE
fix: PWA インストール済み時にマニュアルガイドが誤表示される問題を修正

### DIFF
--- a/src/hooks/use-pwa-install.ts
+++ b/src/hooks/use-pwa-install.ts
@@ -75,9 +75,11 @@ export function usePwaInstall() {
     } as const;
   }
 
+  const supportsInstallPrompt = "onbeforeinstallprompt" in window;
+
   return {
     hasNativeInstall,
-    showManualGuide: !hasNativeInstall,
+    showManualGuide: !hasNativeInstall && !supportsInstallPrompt,
     isInstalled,
     promptInstall,
   } as const;


### PR DESCRIPTION
## Summary
- Chrome 系ブラウザで PWA インストール済みの場合、`beforeinstallprompt` が発火しないため `showManualGuide` が true になり「ホーム画面に追加」の手動ガイドが表示されていた
- `onbeforeinstallprompt` プロパティの存在チェックで Chrome 系かどうかを判定し、対応ブラウザではプロンプトが来ない＝インストール済みとしてバナーを非表示にする
- Safari/Firefox など非対応ブラウザでは従来通りマニュアルガイドを表示

## Test plan
- [ ] Chrome でインストール済みの状態で招待ページを開き、出欠回答後にバナーが出ないことを確認
- [ ] Chrome で未インストールの状態で出欠回答後に「ホーム画面に追加」ボタンが表示されることを確認
- [ ] Safari（iOS）で出欠回答後にマニュアルガイドが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)